### PR TITLE
WebParser: Add option to specify proxy as None

### DIFF
--- a/Plugins/PluginWebParser/WebParser.cpp
+++ b/Plugins/PluginWebParser/WebParser.cpp
@@ -550,6 +550,12 @@ PLUGIN_EXPORT void Initialize(void** data, void* rm)
 		FillCharacterEntityReferences();
 
 		LPCWSTR proxy = RmReadString(rm, L"ProxyServer", L"");
+		
+		if (_wcsnicmp(proxy, L"none", 4) == 0)
+		{
+			proxy = NULL;
+		}
+		
 		g_InternetHandle = InternetOpen(L"Rainmeter WebParser plugin",
 			*proxy ? INTERNET_OPEN_TYPE_PROXY : INTERNET_OPEN_TYPE_PRECONFIG,
 			*proxy ? proxy : NULL,


### PR DESCRIPTION
Since rainmeter uses the IE proxy configuration by default,  we need a way to bypass this behavior for any measure.

The WebParser plugin provides an option "ProxyServer" to  specify the proxy server to be used in the measure, we use  that option to also allow input as None which can be used  to bypass the default proxy.
