### PR TITLE
GetOption() can now get values inherited from MeterStyles.

### DIFF
--- a/Library/lua/glue/LuaMeasure.cpp
+++ b/Library/lua/glue/LuaMeasure.cpp
@@ -42,8 +42,14 @@ static int GetOption(lua_State* L)
 
 	const std::wstring section = LuaManager::ToWide(2);
 	const std::wstring defValue = LuaManager::ToWide(3);
+	const std::wstring& style = parser.ReadString(self->GetName(), L"MeterStyle", L"");
+	if (!style.empty())
+	{
+		parser.SetStyleTemplate(style);
+	}
 	const std::wstring& value =
 		parser.ReadString(self->GetName(), section.c_str(), defValue.c_str());
+	parser.ClearStyleTemplate();
 	LuaManager::PushWide(value);
 	return 1;
 }

--- a/Library/lua/glue/LuaMeter.cpp
+++ b/Library/lua/glue/LuaMeter.cpp
@@ -42,8 +42,14 @@ static int GetOption(lua_State* L)
 
 	const std::wstring section = LuaManager::ToWide(2);
 	const std::wstring defValue = LuaManager::ToWide(3);
+	const std::wstring& style = parser.ReadString(self->GetName(), L"MeterStyle", L"");
+	if (!style.empty())
+	{
+		parser.SetStyleTemplate(style);
+	}
 	const std::wstring& value =
 		parser.ReadString(self->GetName(), section.c_str(), defValue.c_str());
+	parser.ClearStyleTemplate();
 	LuaManager::PushWide(value);
 	return 1;
 }


### PR DESCRIPTION
The GetOption() function in Lua was unable to get any options that were inherited from meterstyles. This commit fixes that.
