### PR TITLE
Update NSIS path in build batch file

### DIFF
--- a/Build/Build.bat
+++ b/Build/Build.bat
@@ -33,6 +33,10 @@ if "%1" == "BUILDLANGUAGES" goto BUILDLANGUAGES
 
 if exist "%MAKENSIS%" goto NSISFOUND
 set MAKENSIS=%MAKENSIS:Program Files\=Program Files (x86)\%
+if exist "%MAKENSIS%" goto NSISFOUND
+set MAKENSIS=%PROGRAMFILES%\NSIS\Unicode\MakeNSIS.exe
+if exist "%MAKENSIS%" goto NSISFOUND
+set MAKENSIS=%MAKENSIS:Program Files\=Program Files (x86)\%
 if not exist "%MAKENSIS%" echo ERROR: MakeNSIS.exe not found & goto END
 :NSISFOUND
 


### PR DESCRIPTION
When I execute build batch file having NSIS 2.46.5 Unicode installed on my system, it shows "ERROR: MakeNSIS.exe not found". On debugging the build batch I found that in NSIS 2.46.5 Unicode path has been changed to %PROGRAMFILES%\NSIS\MakeNSIS.exe to %PROGRAMFILES%\NSIS\Unicode\MakeNSIS.exe
