### PR TITLE
PluginNowPlaying fix. Art was fetched from mp3(embedded) well, but not so with images inside the music's folder

### DIFF
--- a/Plugins/PluginNowPlaying/Cover.cpp
+++ b/Plugins/PluginNowPlaying/Cover.cpp
@@ -117,6 +117,9 @@ bool ExtractMP4(TagLib::MP4::File* file, const std::wstring& target)
 
 }  // namespace
 
+
+const LPCTSTR CCover::localCoverExtName[localCoverExtCount] = { L"jpg", L"jpeg", L"png", L"bmp" };
+
 /*
 ** Checks if cover art is in cache.
 **
@@ -137,12 +140,9 @@ bool CCover::GetLocal(std::wstring filename, const std::wstring& folder, std::ws
 	testPath += L".";
 	std::wstring::size_type origLen = testPath.length();
 
-	const int extCount = 4;
-	LPCTSTR extName[extCount] = { L"jpg", L"jpeg", L"png", L"bmp" };
-
-	for (int i = 0; i < extCount; ++i)
+	for (int i = 0; i < localCoverExtCount; ++i)
 	{
-		testPath += extName[i];
+		testPath += localCoverExtName[i];
 		if (_waccess(testPath.c_str(), 0) == 0)
 		{
 			target = testPath;
@@ -156,6 +156,37 @@ bool CCover::GetLocal(std::wstring filename, const std::wstring& folder, std::ws
 	}
 
 	return false;
+}
+bool CCover::GetLocalAnyImage(const std::wstring& folder, std::wstring& target)
+{
+	std::wstring testPath = folder;
+	std::wstring::size_type origLen = testPath.length();
+
+	LPCWSTR lpFileName;
+	WIN32_FIND_DATA FindFileData;
+
+	HANDLE hFind;
+	for (int i = 0; i < localCoverExtCount; ++i)
+	{
+		testPath += L"*.";
+		testPath += localCoverExtName[i];
+		lpFileName = testPath.c_str();
+		
+		hFind = FindFirstFile(lpFileName, &FindFileData);
+		if (hFind != INVALID_HANDLE_VALUE
+			&& (FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0)
+		{
+			std::wstring imagePath = folder;
+			imagePath += FindFileData.cFileName;
+			target = imagePath;
+			return true;
+		}
+		else
+		{
+			// Get rid of the added extension
+			testPath.resize(origLen);
+		}
+	}
 }
 
 /*

--- a/Plugins/PluginNowPlaying/Cover.h
+++ b/Plugins/PluginNowPlaying/Cover.h
@@ -43,8 +43,12 @@ class CCover
 public:
 	static bool GetCached(std::wstring& path);
 	static bool GetLocal(std::wstring filename, const std::wstring& folder, std::wstring& target);
+	static bool GetLocalAnyImage(const std::wstring& folder, std::wstring& target);
 	static bool GetEmbedded(const TagLib::FileRef& fr, const std::wstring& target);
 	static std::wstring GetFileFolder(const std::wstring& file);
+private:
+	static const int localCoverExtCount = 4;
+	static const LPCTSTR localCoverExtName[localCoverExtCount];
 };
 
 #endif

--- a/Plugins/PluginNowPlaying/Player.cpp
+++ b/Plugins/PluginNowPlaying/Player.cpp
@@ -121,8 +121,12 @@ void Player::FindCover()
 	{
 		std::wstring trackFolder = CCover::GetFileFolder(m_FilePath);
 
-		if (!CCover::GetLocal(L"cover", trackFolder, m_CoverPath) &&
-			!CCover::GetLocal(L"folder", trackFolder, m_CoverPath))
+		if (!CCover::GetLocal(m_Artist, trackFolder, m_CoverPath) &&
+			!CCover::GetLocal(L"CD", trackFolder, m_CoverPath) &&
+			!CCover::GetLocal(L"front", trackFolder, m_CoverPath) &&
+			!CCover::GetLocal(L"cover", trackFolder, m_CoverPath) &&
+			!CCover::GetLocal(L"folder", trackFolder, m_CoverPath) &&
+			!CCover::GetLocal(m_Album, trackFolder, m_CoverPath))
 		{
 			// Nothing found
 			m_CoverPath.clear();

--- a/Plugins/PluginNowPlaying/Player.cpp
+++ b/Plugins/PluginNowPlaying/Player.cpp
@@ -121,12 +121,13 @@ void Player::FindCover()
 	{
 		std::wstring trackFolder = CCover::GetFileFolder(m_FilePath);
 
-		if (!CCover::GetLocal(m_Artist, trackFolder, m_CoverPath) &&
-			!CCover::GetLocal(L"CD", trackFolder, m_CoverPath) &&
+		if (!CCover::GetLocal(m_Album, trackFolder, m_CoverPath) &&
 			!CCover::GetLocal(L"front", trackFolder, m_CoverPath) &&
 			!CCover::GetLocal(L"cover", trackFolder, m_CoverPath) &&
 			!CCover::GetLocal(L"folder", trackFolder, m_CoverPath) &&
-			!CCover::GetLocal(m_Album, trackFolder, m_CoverPath))
+			!CCover::GetLocal(L"CD", trackFolder, m_CoverPath) &&
+			!CCover::GetLocal(m_Artist, trackFolder, m_CoverPath) &&
+			!CCover::GetLocalAnyImage(trackFolder, m_CoverPath))
 		{
 			// Nothing found
 			m_CoverPath.clear();


### PR DESCRIPTION
... support for cover art searching in the music folder was very limited.
It worked only if you have a file named exactly as "cover" or  "folder" and an image file extension.

I have expanded it to search the most popular naming schemes for cover art image files.
In addition I've added a fallback mechanism that grabs any image from the folder, if none of the naming schemes were matched.

These behaviors are more in line with the way that music player programs themselves search the folder.
