### PR TITLE
Fixed button ID_STR_COPYTOCLIPBOARD width

### DIFF
--- a/Library/DialogAbout.cpp
+++ b/Library/DialogAbout.cpp
@@ -1224,7 +1224,7 @@ void DialogAbout::TabVersion::Create(HWND owner)
 			0, 82, 360, 9,
 			WS_VISIBLE | SS_ENDELLIPSIS | SS_NOPREFIX, 0),
 		CT_BUTTON(Id_CopyButton, ID_STR_COPYTOCLIPBOARD,
-			0, 98, buttonWidth + 25, 14,
+			0, 98, buttonWidth + 35, 14,
 			WS_VISIBLE | WS_TABSTOP, 0)
 	};
 


### PR DESCRIPTION
In the Russian localization string does not intermeddle in the button width. The width was increased from 25 to 35.