### PR TITLE
Audiolevel Waveform Support

### DIFF
--- a/Library/Measure.h
+++ b/Library/Measure.h
@@ -1,9 +1,20 @@
-/* Copyright (C) 2001 Rainmeter Project Developers
- *
- * This Source Code Form is subject to the terms of the GNU General Public
- * License; either version 2 of the License, or (at your option) any later
- * version. If a copy of the GPL was not distributed with this file, You can
- * obtain one at <https://www.gnu.org/licenses/gpl-2.0.html>. */
+/*
+  Copyright (C) 2001 Kimmo Pekkola
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
 
 #ifndef __MEASURE_H__
 #define __MEASURE_H__
@@ -14,6 +25,8 @@
 #include "IfActions.h"
 #include "Util.h"
 #include "Section.h"
+#include <ole2.h>  // For Gdiplus.h.
+#include <gdiplus.h>
 
 enum AUTOSCALE
 {
@@ -73,6 +86,8 @@ public:
 	virtual const WCHAR* GetStringValue();
 	const WCHAR* GetStringOrFormattedValue(AUTOSCALE autoScale, double scale, int decimals, bool percentual);
 	const WCHAR* GetFormattedValue(AUTOSCALE autoScale, double scale, int decimals, bool percentual);
+
+	virtual Gdiplus::Bitmap* GetBitmap() { return nullptr; }
 
 	static void GetScaledValue(AUTOSCALE autoScale, int decimals, double theValue, WCHAR* buffer, size_t sizeInWords);
 	static void RemoveTrailingZero(WCHAR* str, int strLen);

--- a/Library/Measure.h
+++ b/Library/Measure.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2000 Rainmeter Project Developers
+/* Copyright (C) 2001 Rainmeter Project Developers
  *
  * This Source Code Form is subject to the terms of the GNU General Public
  * License; either version 2 of the License, or (at your option) any later

--- a/Library/Measure.h
+++ b/Library/Measure.h
@@ -1,20 +1,9 @@
-/*
-  Copyright (C) 2001 Kimmo Pekkola
-
-  This program is free software; you can redistribute it and/or
-  modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation; either version 2
-  of the License, or (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/
+/* Copyright (C) 2000 Rainmeter Project Developers
+ *
+ * This Source Code Form is subject to the terms of the GNU General Public
+ * License; either version 2 of the License, or (at your option) any later
+ * version. If a copy of the GPL was not distributed with this file, You can
+ * obtain one at <https://www.gnu.org/licenses/gpl-2.0.html>. */
 
 #ifndef __MEASURE_H__
 #define __MEASURE_H__

--- a/Library/MeasurePlugin.cpp
+++ b/Library/MeasurePlugin.cpp
@@ -1,9 +1,20 @@
-/* Copyright (C) 2001 Rainmeter Project Developers
- *
- * This Source Code Form is subject to the terms of the GNU General Public
- * License; either version 2 of the License, or (at your option) any later
- * version. If a copy of the GPL was not distributed with this file, You can
- * obtain one at <https://www.gnu.org/licenses/gpl-2.0.html>. */
+/*
+  Copyright (C) 2001 Kimmo Pekkola
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
 
 #include "StdAfx.h"
 #include "MeasurePlugin.h"
@@ -20,7 +31,8 @@ MeasurePlugin::MeasurePlugin(Skin* skin, const WCHAR* name) : Measure(skin, name
 	m_PluginData(),
 	m_UpdateFunc(),
 	m_GetStringFunc(),
-	m_ExecuteBangFunc()
+	m_ExecuteBangFunc(),
+	m_GetBitmapFunc()
 {
 }
 
@@ -134,6 +146,7 @@ void MeasurePlugin::ReadOptions(ConfigParser& parser, const WCHAR* section)
 	m_UpdateFunc = GetProcAddress(m_Plugin, "Update");
 	m_GetStringFunc = GetProcAddress(m_Plugin, "GetString");
 	m_ExecuteBangFunc = GetProcAddress(m_Plugin, "ExecuteBang");
+	m_GetBitmapFunc = GetProcAddress(m_Plugin, "GetBitmap");
 
 	// Remove current directory from DLL search path
 	SetDllDirectory(L"");
@@ -236,4 +249,25 @@ void MeasurePlugin::Command(const std::wstring& command)
 	{
 		Measure::Command(command);
 	}
+}
+
+/*
+** Gets the bitmap from the plugin.
+**
+*/
+Gdiplus::Bitmap* MeasurePlugin::GetBitmap()
+{
+	if (m_GetBitmapFunc)
+	{
+		if (IsNewApi())
+		{
+			return ((NEWGETBITMAP)m_GetBitmapFunc)(m_PluginData);
+		}
+		else
+		{
+			return ((GETBITMAP)m_GetStringFunc)(m_ID);
+		}
+	}
+
+	return nullptr;
 }

--- a/Library/MeasurePlugin.cpp
+++ b/Library/MeasurePlugin.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2000 Rainmeter Project Developers
+/* Copyright (C) 2001 Rainmeter Project Developers
  *
  * This Source Code Form is subject to the terms of the GNU General Public
  * License; either version 2 of the License, or (at your option) any later

--- a/Library/MeasurePlugin.cpp
+++ b/Library/MeasurePlugin.cpp
@@ -1,20 +1,9 @@
-/*
-  Copyright (C) 2001 Kimmo Pekkola
-
-  This program is free software; you can redistribute it and/or
-  modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation; either version 2
-  of the License, or (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/
+/* Copyright (C) 2000 Rainmeter Project Developers
+ *
+ * This Source Code Form is subject to the terms of the GNU General Public
+ * License; either version 2 of the License, or (at your option) any later
+ * version. If a copy of the GPL was not distributed with this file, You can
+ * obtain one at <https://www.gnu.org/licenses/gpl-2.0.html>. */
 
 #include "StdAfx.h"
 #include "MeasurePlugin.h"

--- a/Library/MeasurePlugin.h
+++ b/Library/MeasurePlugin.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2000 Rainmeter Project Developers
+/* Copyright (C) 2001 Rainmeter Project Developers
  *
  * This Source Code Form is subject to the terms of the GNU General Public
  * License; either version 2 of the License, or (at your option) any later

--- a/Library/MeasurePlugin.h
+++ b/Library/MeasurePlugin.h
@@ -1,9 +1,20 @@
-/* Copyright (C) 2001 Rainmeter Project Developers
- *
- * This Source Code Form is subject to the terms of the GNU General Public
- * License; either version 2 of the License, or (at your option) any later
- * version. If a copy of the GPL was not distributed with this file, You can
- * obtain one at <https://www.gnu.org/licenses/gpl-2.0.html>. */
+/*
+  Copyright (C) 2001 Kimmo Pekkola
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
 
 #ifndef __MEASUREPLUGIN_H__
 #define __MEASUREPLUGIN_H__
@@ -17,6 +28,7 @@ typedef UINT (*UPDATE)(UINT);
 typedef double (*UPDATE2)(UINT);
 typedef LPCTSTR (*GETSTRING)(UINT, UINT);
 typedef void (*EXECUTEBANG)(LPCWSTR, UINT);
+typedef Gdiplus::Bitmap* (*GETBITMAP)(UINT);
 
 typedef void (*NEWINITIALIZE)(void*, void*);
 typedef void (*NEWRELOAD)(void*, void*, double*);
@@ -24,6 +36,7 @@ typedef void (*NEWFINALIZE)(void*);
 typedef double (*NEWUPDATE)(void*);
 typedef LPCWSTR (*NEWGETSTRING)(void*);
 typedef void (*NEWEXECUTEBANG)(void*, LPCWSTR);
+typedef Gdiplus::Bitmap* (*NEWGETBITMAP)(void*);
 
 class MeasurePlugin : public Measure
 {
@@ -38,6 +51,7 @@ public:
 
 	virtual const WCHAR* GetStringValue();
 	virtual void Command(const std::wstring& command);
+	virtual Gdiplus::Bitmap* GetBitmap();
 
 protected:
 	virtual void ReadOptions(ConfigParser& parser, const WCHAR* section);
@@ -67,6 +81,7 @@ private:
 	void* m_UpdateFunc;
 	void* m_GetStringFunc;
 	void* m_ExecuteBangFunc;
+	void* m_GetBitmapFunc;
 };
 
 #endif

--- a/Library/MeasurePlugin.h
+++ b/Library/MeasurePlugin.h
@@ -1,20 +1,9 @@
-/*
-  Copyright (C) 2001 Kimmo Pekkola
-
-  This program is free software; you can redistribute it and/or
-  modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation; either version 2
-  of the License, or (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/
+/* Copyright (C) 2000 Rainmeter Project Developers
+ *
+ * This Source Code Form is subject to the terms of the GNU General Public
+ * License; either version 2 of the License, or (at your option) any later
+ * version. If a copy of the GPL was not distributed with this file, You can
+ * obtain one at <https://www.gnu.org/licenses/gpl-2.0.html>. */
 
 #ifndef __MEASUREPLUGIN_H__
 #define __MEASUREPLUGIN_H__

--- a/Library/MeterImage.cpp
+++ b/Library/MeterImage.cpp
@@ -175,8 +175,15 @@ bool MeterImage::Update()
 			Bitmap* bitmap = (!m_Measures.empty())? m_Measures[0]->GetBitmap() : nullptr;
 			if (bitmap)
 			{
-				InitSize(bitmap);
-				m_Bitmap = bitmap;
+				if(m_Bitmap) delete m_Bitmap;
+
+				// Convert loaded image to faster blittable bitmap (may increase memory usage slightly)
+				Rect r(0, 0, bitmap->GetWidth(), bitmap->GetHeight());
+				m_Bitmap = new Bitmap(r.Width, r.Height, PixelFormat32bppPARGB);
+				Graphics graphics(m_Bitmap);
+				graphics.DrawImage(bitmap, r, 0, 0, r.Width, r.Height, UnitPixel);
+
+				InitSize(m_Bitmap);
 			}
 			else
 			{

--- a/Library/MeterImage.cpp
+++ b/Library/MeterImage.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2000 Rainmeter Project Developers
+/* Copyright (C) 2002 Rainmeter Project Developers
  *
  * This Source Code Form is subject to the terms of the GNU General Public
  * License; either version 2 of the License, or (at your option) any later

--- a/Library/MeterImage.cpp
+++ b/Library/MeterImage.cpp
@@ -1,20 +1,9 @@
-/*
-  Copyright (C) 2002 Kimmo Pekkola
-
-  This program is free software; you can redistribute it and/or
-  modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation; either version 2
-  of the License, or (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/
+/* Copyright (C) 2000 Rainmeter Project Developers
+ *
+ * This Source Code Form is subject to the terms of the GNU General Public
+ * License; either version 2 of the License, or (at your option) any later
+ * version. If a copy of the GPL was not distributed with this file, You can
+ * obtain one at <https://www.gnu.org/licenses/gpl-2.0.html>. */
 
 #include "StdAfx.h"
 #include "MeterImage.h"

--- a/Library/MeterImage.cpp
+++ b/Library/MeterImage.cpp
@@ -1,9 +1,20 @@
-/* Copyright (C) 2002 Rainmeter Project Developers
- *
- * This Source Code Form is subject to the terms of the GNU General Public
- * License; either version 2 of the License, or (at your option) any later
- * version. If a copy of the GPL was not distributed with this file, You can
- * obtain one at <https://www.gnu.org/licenses/gpl-2.0.html>. */
+/*
+  Copyright (C) 2002 Kimmo Pekkola
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
 
 #include "StdAfx.h"
 #include "MeterImage.h"
@@ -21,6 +32,7 @@ TintedImageHelper_DefineOptionArray(MeterImage::c_MaskOptionArray, L"Mask");
 MeterImage::MeterImage(Skin* skin, const WCHAR* name) : Meter(skin, name),
 	m_Image(L"ImageName", nullptr, false, skin),
 	m_MaskImage(L"MaskImageName", c_MaskOptionArray, false, skin),
+	m_Bitmap(nullptr),
 	m_NeedsRedraw(false),
 	m_DrawMode(DRAWMODE_NONE),
 	m_ScaleMargins()
@@ -52,10 +64,13 @@ void MeterImage::Initialize()
 */
 void MeterImage::LoadImage(const std::wstring& imageName, bool bLoadAlways)
 {
+	m_Bitmap = nullptr;
 	m_Image.LoadImage(imageName, bLoadAlways);
 
 	if (m_Image.IsLoaded())
 	{
+		m_Bitmap = m_Image.GetImage();
+
 		bool useMaskSize = false;
 		if (m_Skin->GetUseD2D())
 		{
@@ -66,30 +81,38 @@ void MeterImage::LoadImage(const std::wstring& imageName, bool bLoadAlways)
 
 		// Calculate size of the meter
 		Bitmap* bitmap = useMaskSize ? m_MaskImage.GetImage() : m_Image.GetImage();
+		InitSize(bitmap);
+	}
+}
 
-		int imageW = bitmap->GetWidth();
-		int imageH = bitmap->GetHeight();
+/*
+** Initialize image size from a bitmap
+**
+*/
+void MeterImage::InitSize(Bitmap* bitmap)
+{
+	int imageW = bitmap->GetWidth();
+	int imageH = bitmap->GetHeight();
 
-		if (m_WDefined)
+	if (m_WDefined)
+	{
+		if (!m_HDefined)
 		{
-			if (!m_HDefined)
-			{
-				m_H = (imageW == 0) ? 0 : (m_DrawMode == DRAWMODE_TILE) ? imageH : m_W * imageH / imageW;
-				m_H += GetHeightPadding();
-			}
+			m_H = (imageW == 0) ? 0 : (m_DrawMode == DRAWMODE_TILE) ? imageH : m_W * imageH / imageW;
+			m_H += GetHeightPadding();
+		}
+	}
+	else
+	{
+		if (m_HDefined)
+		{
+			m_W = (imageH == 0) ? 0 : (m_DrawMode == DRAWMODE_TILE) ? imageW : m_H * imageW / imageH;
+			m_W += GetWidthPadding();
 		}
 		else
 		{
-			if (m_HDefined)
-			{
-				m_W = (imageH == 0) ? 0 : (m_DrawMode == DRAWMODE_TILE) ? imageW : m_H * imageW / imageH;
-				m_W += GetWidthPadding();
-			}
-			else
-			{
-				m_W = imageW + GetWidthPadding();
-				m_H = imageH + GetHeightPadding();
-			}
+			m_W = imageW + GetWidthPadding();
+			m_H = imageH + GetHeightPadding();
 		}
 	}
 }
@@ -159,31 +182,41 @@ bool MeterImage::Update()
 	{
 		if (!m_Measures.empty() || m_DynamicVariables)
 		{
-			// Store the current values so we know if the image needs to be updated
-			std::wstring oldResult = m_ImageNameResult;
-
-			if (!m_Measures.empty())  // read from the measures
+			// allow measure to supply the bitmap
+			Bitmap* bitmap = (!m_Measures.empty())? m_Measures[0]->GetBitmap() : nullptr;
+			if (bitmap)
 			{
-				if (m_ImageName.empty())
+				InitSize(bitmap);
+				m_Bitmap = bitmap;
+			}
+			else
+			{
+				// Store the current values so we know if the image needs to be updated
+				std::wstring oldResult = m_ImageNameResult;
+
+				if (!m_Measures.empty())  // read from the measures
 				{
-					m_ImageNameResult = m_Measures[0]->GetStringOrFormattedValue(AUTOSCALE_OFF, 1, 0, false);
-				}
-				else
-				{
-					m_ImageNameResult = m_ImageName;
-					if (!ReplaceMeasures(m_ImageNameResult, AUTOSCALE_OFF))
+					if (m_ImageName.empty())
 					{
-						// ImageName doesn't contain any measures, so use the result of MeasureName.
 						m_ImageNameResult = m_Measures[0]->GetStringOrFormattedValue(AUTOSCALE_OFF, 1, 0, false);
 					}
+					else
+					{
+						m_ImageNameResult = m_ImageName;
+						if (!ReplaceMeasures(m_ImageNameResult, AUTOSCALE_OFF))
+						{
+							// ImageName doesn't contain any measures, so use the result of MeasureName.
+							m_ImageNameResult = m_Measures[0]->GetStringOrFormattedValue(AUTOSCALE_OFF, 1, 0, false);
+						}
+					}
 				}
-			}
-			else  // read from the skin
-			{
-				m_ImageNameResult = m_ImageName;
-			}
+				else  // read from the skin
+				{
+					m_ImageNameResult = m_ImageName;
+				}
 
-			LoadImage(m_ImageNameResult, (wcscmp(oldResult.c_str(), m_ImageNameResult.c_str()) != 0));
+				LoadImage(m_ImageNameResult, (wcscmp(oldResult.c_str(), m_ImageNameResult.c_str()) != 0));
+			}
 
 			return true;
 		}
@@ -204,10 +237,10 @@ bool MeterImage::Draw(Gfx::Canvas& canvas)
 {
 	if (!Meter::Draw(canvas)) return false;
 
-	if (m_Image.IsLoaded())
+	if (m_Bitmap)
 	{
 		// Copy the image over the doublebuffer
-		Bitmap* drawBitmap = m_Image.GetImage();
+		Bitmap* drawBitmap = m_Bitmap;
 
 		int imageW = drawBitmap->GetWidth();
 		int imageH = drawBitmap->GetHeight();

--- a/Library/MeterImage.h
+++ b/Library/MeterImage.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2000 Rainmeter Project Developers
+/* Copyright (C) 2002 Rainmeter Project Developers
  *
  * This Source Code Form is subject to the terms of the GNU General Public
  * License; either version 2 of the License, or (at your option) any later

--- a/Library/MeterImage.h
+++ b/Library/MeterImage.h
@@ -1,9 +1,20 @@
-/* Copyright (C) 2002 Rainmeter Project Developers
- *
- * This Source Code Form is subject to the terms of the GNU General Public
- * License; either version 2 of the License, or (at your option) any later
- * version. If a copy of the GPL was not distributed with this file, You can
- * obtain one at <https://www.gnu.org/licenses/gpl-2.0.html>. */
+/*
+  Copyright (C) 2002 Kimmo Pekkola
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
 
 #ifndef __METERIMAGE_H__
 #define __METERIMAGE_H__
@@ -42,6 +53,7 @@ private:
 	};
 
 	void LoadImage(const std::wstring& imageName, bool bLoadAlways);
+	void InitSize(Gdiplus::Bitmap* bitmap);
 
 	TintedImage m_Image;
 	std::wstring m_ImageName;
@@ -49,6 +61,8 @@ private:
 
 	TintedImage m_MaskImage;
 	std::wstring m_MaskImageName;
+
+	Gdiplus::Bitmap* m_Bitmap;
 
 	bool m_NeedsRedraw;
 	DRAWMODE m_DrawMode;

--- a/Library/MeterImage.h
+++ b/Library/MeterImage.h
@@ -1,20 +1,9 @@
-/*
-  Copyright (C) 2002 Kimmo Pekkola
-
-  This program is free software; you can redistribute it and/or
-  modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation; either version 2
-  of the License, or (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/
+/* Copyright (C) 2000 Rainmeter Project Developers
+ *
+ * This Source Code Form is subject to the terms of the GNU General Public
+ * License; either version 2 of the License, or (at your option) any later
+ * version. If a copy of the GPL was not distributed with this file, You can
+ * obtain one at <https://www.gnu.org/licenses/gpl-2.0.html>. */
 
 #ifndef __METERIMAGE_H__
 #define __METERIMAGE_H__

--- a/Plugins/PluginAudioLevel/PluginAudioLevel.cpp
+++ b/Plugins/PluginAudioLevel/PluginAudioLevel.cpp
@@ -1,20 +1,9 @@
-/*
-  Copyright (C) 2014 David Grace
-
-  This program is free software; you can redistribute it and/or
-  modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation; either version 2
-  of the License, or (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/
+/* Copyright (C) 2014 Rainmeter Project Developers
+ *
+ * This Source Code Form is subject to the terms of the GNU General Public
+ * License; either version 2 of the License, or (at your option) any later
+ * version. If a copy of the GPL was not distributed with this file, You can
+ * obtain one at <https://www.gnu.org/licenses/gpl-2.0.html>. */
 
 #include <Windows.h>
 #include <cstdio>

--- a/Plugins/PluginAudioLevel/PluginAudioLevel.vcxproj
+++ b/Plugins/PluginAudioLevel/PluginAudioLevel.vcxproj
@@ -22,6 +22,18 @@
     </ClCompile>
     <Link>
     </Link>
+    <Link>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">gdiplus.lib;$(SolutionDir)Plugins\API\x64\Rainmeter.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Link>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|x64'">gdiplus.lib;$(SolutionDir)Plugins\API\x64\Rainmeter.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Link>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">gdiplus.lib;$(SolutionDir)Plugins\API\x32\Rainmeter.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Link>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">gdiplus.lib;$(SolutionDir)Plugins\API\x32\Rainmeter.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="PluginAudioLevel.cpp" />


### PR DESCRIPTION
Here's a cleaner pull request for the AudioLevel bitmap-plugin support.  (I had to nuke my old fork and create a new one)  Features:

 - new GetBitmap() method on measures to provide 2d pixel data
 - MeasurePlugin implements GetBitmap() with a new DLL function
 - AudioLevel implements GetBitmap() by creating a GdiPlus::Bitmap and updating pixel data each frame
 - MeterImage can display bitmaps from the measure's GetBitmap() call, but currently no tint/colormatrix support.  Broke out the size initialization stuff from LoadImage to its own InitSize function.