### PR TITLE
Changed PluginQuote to use FileUtils::ReadFullFile.

### DIFF
--- a/Plugins/PluginQuote/PluginQuote.vcxproj
+++ b/Plugins/PluginQuote/PluginQuote.vcxproj
@@ -28,10 +28,12 @@
     <ResourceCompile Include="PluginQuote.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\Common\FileUtil.cpp" />
     <ClCompile Include="..\..\Common\StringUtil.cpp" />
     <ClCompile Include="Quote.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\Common\FileUtil.h" />
     <ClInclude Include="..\..\Common\StringUtil.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
As suggested [here](https://github.com/rainmeter/rainmeter/pull/55#issuecomment-156721889). Original implementation used to buffer the file and operate on it in chunks saving some memory on large files. This patch loads whole file in the buffer and so if used with large files causes increase in memory consumption.