### PR TITLE
Fixed issue with W/H options and Clipstring=1

### DIFF
--- a/Library/MeterString.cpp
+++ b/Library/MeterString.cpp
@@ -370,8 +370,10 @@ bool MeterString::Update()
 			RectF rect;
 			if (DrawString(m_Skin->GetCanvas(), &rect))
 			{
-				m_W = (int)rect.Width + GetWidthPadding();
-				m_H = (int)rect.Height + GetHeightPadding();
+				if (!m_WDefined)
+					m_W = (int)rect.Width + GetWidthPadding();
+				if (!m_HDefined)
+					m_H = (int)rect.Height + GetHeightPadding();
 			}
 			else
 			{


### PR DESCRIPTION
When specifying a W= for a string, but not H= and using Clipstring=1, a new width value would be calculated by D2D and overwritten, making the string no longer clip and instead extend the meter width to accommodate the entire string

This small fix only changes the width or height if you did not explicitly define one or the other.