### PR TITLE
Get WiFi link speed. Works, but currently ignores the interface index…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Certificate.bat
 *.suo
 *.txt
 *.user
+/Rainmeter.VC.db


### PR DESCRIPTION
Please consider adapting this code to provide link speed as well as signal quality from the WifiStatus plugin.

Note that both PerfMon and WlanEnumInterfaces() currently return differently bogus link rates. Only getAdapterAddresses() appears to work.
