### PR TITLE
Better accuracy in NowPlaying for SetPosition and Progress

### DIFF
--- a/Library/MeasureNowPlaying.cpp
+++ b/Library/MeasureNowPlaying.cpp
@@ -330,7 +330,7 @@ void MeasureNowPlaying::UpdateValue()
 	case MEASURE_PROGRESS:
 		if (player->GetDuration())
 		{
-			m_Value = (player->GetPosition() * 100) / player->GetDuration();
+			m_Value = ((double)player->GetPosition() * 100) / player->GetDuration();
 		}
 		break;
 	case MEASURE_RATING:
@@ -468,7 +468,7 @@ void MeasureNowPlaying::Command(const std::wstring& command)
 
 			if (_wcsnicmp(args, L"SetPosition", 11) == 0)
 			{
-				int position = (_wtoi(arg) * (int)player->GetDuration()) / 100;
+				int position = (int)(_wtof(arg) * player->GetDuration()) / 100;
 				if (arg[0] == L'+' || arg[0] == L'-')
 				{
 					position += player->GetPosition();


### PR DESCRIPTION
Measure Progress no longer divides Position and Duration into an integer causing an unneeded
loss of data.
SetPosition no longer reads the string as an int but instead reads it as
a float.

These changes are important to maintain accuracy in longer songs.