### PR TITLE
Spotify and iTunes now playing fixes

### DIFF
--- a/Library/NowPlaying/PlayerITunes.cpp
+++ b/Library/NowPlaying/PlayerITunes.cpp
@@ -400,47 +400,47 @@ void PlayerITunes::OnTrackChange()
 			{
 				++m_TrackCount;
 				m_FilePath = tmpStr;
+			}
+		}
 
-				if (m_Measures & MEASURE_COVER)
+		if (m_Measures & MEASURE_COVER)
+		{
+			m_CoverPath.clear();
+
+			// Check for embedded art through iTunes interface
+			IITArtworkCollection* artworkCollection;
+			hr = track->get_Artwork(&artworkCollection);
+
+			if (SUCCEEDED(hr))
+			{
+				long count;
+				artworkCollection->get_Count(&count);
+
+				if (count > 0)
 				{
-					m_CoverPath.clear();
-
-					// Check for embedded art through iTunes interface
-					IITArtworkCollection* artworkCollection;
-					hr = track->get_Artwork(&artworkCollection);
+					IITArtwork* artwork;
+					hr = artworkCollection->get_Item(1, &artwork);
 
 					if (SUCCEEDED(hr))
 					{
-						long count;
-						artworkCollection->get_Count(&count);
-
-						if (count > 0)
+						_bstr_t coverPath = m_TempCoverPath.c_str();
+						hr = artwork->SaveArtworkToFile(coverPath);
+						if (SUCCEEDED(hr))
 						{
-							IITArtwork* artwork;
-							hr = artworkCollection->get_Item(1, &artwork);
-
-							if (SUCCEEDED(hr))
-							{
-								_bstr_t coverPath = m_TempCoverPath.c_str();
-								hr = artwork->SaveArtworkToFile(coverPath);
-								if (SUCCEEDED(hr))
-								{
-									m_CoverPath = m_TempCoverPath;
-								}
-
-								artwork->Release();
-							}
+							m_CoverPath = m_TempCoverPath;
 						}
 
-						artworkCollection->Release();
+						artwork->Release();
 					}
 				}
 
-				if (m_Measures & MEASURE_LYRICS)
-				{
-					FindLyrics();
-				}
+				artworkCollection->Release();
 			}
+		}
+
+		if (m_Measures & MEASURE_LYRICS)
+		{
+			FindLyrics();
 		}
 
 		track->Release();

--- a/Library/NowPlaying/PlayerSpotify.cpp
+++ b/Library/NowPlaying/PlayerSpotify.cpp
@@ -76,11 +76,13 @@ void PlayerSpotify::UpdateData()
 	{
 		// Parse title and artist from window title
 		WCHAR buffer[256];
-		if (GetWindowText(m_Window, buffer, 256) > 10)
-		{
-			std::wstring title = &buffer[10];  // Skip "Spotify - "
 
-			std::wstring::size_type pos = title.find(L" \u2013 ");
+		//Length of window is now 7 when not playing
+		if (GetWindowText(m_Window, buffer, 256) > 7)
+		{
+			std::wstring title = buffer;
+
+			std::wstring::size_type pos = title.find(L" - ");
 			if (pos != std::wstring::npos)
 			{
 				std::wstring artist(title, 0, pos);


### PR DESCRIPTION
Fixes two different issues in the NowPlaying plugin.

1. Updated the retrieval of Title and Artist from spotify to how it is formatted in the newest version.
2. Moved the check for if current iTunes song has album art to outside the check of if the song is locally on the machine. Even if a song is not played from locally on the machine it still has the album art cached locally.