### PR TITLE
Fix Spotify not always updating state to playing

### DIFF
--- a/Library/NowPlaying/PlayerSpotify.cpp
+++ b/Library/NowPlaying/PlayerSpotify.cpp
@@ -88,10 +88,10 @@ void PlayerSpotify::UpdateData()
 				std::wstring artist(title, 0, pos);
 				pos += 3;  // Skip " - "
 				std::wstring track(title, pos);
+				m_State = STATE_PLAYING;
 
 				if (track != m_Title || artist != m_Artist)
 				{
-					m_State = STATE_PLAYING;
 					m_Title = track;
 					m_Artist = artist;
 					++m_TrackCount;


### PR DESCRIPTION
Setting the state to playing before only happened if there was a change to the title or artist.