### PR TITLE
Fixes shuffle and repeat not updating

### DIFF
--- a/Library/NowPlaying/PlayerITunes.cpp
+++ b/Library/NowPlaying/PlayerITunes.cpp
@@ -306,33 +306,35 @@ bool PlayerITunes::CheckWindow()
 */
 void PlayerITunes::UpdateData()
 {
-	if ((m_Initialized || CheckWindow()) && m_State != STATE_STOPPED)
+	if ((m_Initialized || CheckWindow()))
 	{
-		long position = 0;
-		m_iTunes->get_PlayerPosition(&position);
-		m_Position = (UINT)position;
-	}
-}
-
-/*
-** Called by iTunes event handler when the database is changed.
-**
-*/
-void PlayerITunes::OnDatabaseChange()
-{
-	// Check the shuffle state. TODO: Find better way
-	IITPlaylist* playlist;
-	HRESULT hr = m_iTunes->get_CurrentPlaylist(&playlist);
-	if (SUCCEEDED(hr) && playlist)
-	{
-		VARIANT_BOOL shuffle;
-		hr = playlist->get_Shuffle(&shuffle);
-		if (SUCCEEDED(hr))
+		if (m_State != STATE_STOPPED)
 		{
-			m_Shuffle = shuffle != VARIANT_FALSE;
+			long position = 0;
+			m_iTunes->get_PlayerPosition(&position);
+			m_Position = (UINT)position;
 		}
+		// Check the shuffle and repeat state since there is no onChange event
+		IITPlaylist* playlist;
+		HRESULT hr = m_iTunes->get_CurrentPlaylist(&playlist);
+		if (SUCCEEDED(hr) && playlist)
+		{
+			VARIANT_BOOL shuffle;
+			hr = playlist->get_Shuffle(&shuffle);
+			if (SUCCEEDED(hr))
+			{
+				m_Shuffle = shuffle != VARIANT_FALSE;
+			}
 
-		playlist->Release();
+			ITPlaylistRepeatMode repeat;
+			hr = playlist->get_SongRepeat(&repeat);
+			if (SUCCEEDED(hr))
+			{
+				m_Repeat = repeat != ITPlaylistRepeatModeOff;
+			}
+
+			playlist->Release();
+		}
 	}
 }
 

--- a/Library/NowPlaying/PlayerITunes.cpp
+++ b/Library/NowPlaying/PlayerITunes.cpp
@@ -67,9 +67,6 @@ HRESULT STDMETHODCALLTYPE PlayerITunes::CEventHandler::Invoke(DISPID dispidMembe
 {
 	switch (dispidMember)
 	{
-	case ITEventDatabaseChanged:
-		m_Player->OnDatabaseChange();
-		break;
 
 	case ITEventPlayerPlay:
 		m_Player->OnStateChange(true);
@@ -215,8 +212,6 @@ void PlayerITunes::Initialize()
 		long volume;
 		m_iTunes->get_SoundVolume(&volume);
 		m_Volume = (UINT)volume;
-
-		OnDatabaseChange();
 	}
 	else
 	{

--- a/Library/NowPlaying/PlayerITunes.h
+++ b/Library/NowPlaying/PlayerITunes.h
@@ -65,7 +65,6 @@ private:
 
 	void Initialize();
 	void Uninitialize();
-	void OnDatabaseChange();
 	void OnTrackChange();
 	void OnStateChange(bool playing);
 	void OnVolumeChange(int volume);


### PR DESCRIPTION
Should fix a 4 year old bug that the repeat and shuffle state are not
update except on song change. Also removes some no longer needed code. I
think we could be more agressive and never check repeat or shuffle state
outside updateData but I left those in.