### PR TITLE
Various iTunes fixes

### DIFF
--- a/Library/NowPlaying/PlayerITunes.h
+++ b/Library/NowPlaying/PlayerITunes.h
@@ -21,6 +21,10 @@ public:
 	static Player* Create();
 
 	virtual void UpdateData();
+	virtual void UpdateCachedData();
+
+	//Used to check if track is different
+	IITTrack* m_Track;
 
 	virtual void Pause();
 	virtual void Play();
@@ -54,7 +58,6 @@ private:
 		HRESULT STDMETHODCALLTYPE GetTypeInfoCount(UINT*) { return E_NOTIMPL; }
 		HRESULT STDMETHODCALLTYPE GetTypeInfo(UINT, LCID, ITypeInfo**) { return E_NOTIMPL; }
 		HRESULT STDMETHODCALLTYPE GetIDsOfNames(const IID&, LPOLESTR*, UINT, LCID, DISPID*) { return E_NOTIMPL; }
-		HRESULT STDMETHODCALLTYPE Invoke(DISPID dispidMember, REFIID, LCID, WORD, DISPPARAMS* pDispParams, VARIANT*, EXCEPINFO*, UINT*);
 
 	private:
 		ULONG m_RefCount;
@@ -65,9 +68,6 @@ private:
 
 	void Initialize();
 	void Uninitialize();
-	void OnTrackChange();
-	void OnStateChange(bool playing);
-	void OnVolumeChange(int volume);
 	bool CheckWindow();
 
 	static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);


### PR DESCRIPTION
Fixes a potential crash if a song lacked basic metadata
Fixes TrackChangeAction not being fired if the song did not exist on
disk
Fixes where the album and some metadata would not update if two songs
contained the same basic metadata
Various performance tweaks
Removed outdated code blocks and renamed functions to match new
functionality.