### PR TITLE
iTunes reconnection handling fix

### DIFF
--- a/Library/NowPlaying/PlayerITunes.h
+++ b/Library/NowPlaying/PlayerITunes.h
@@ -24,7 +24,7 @@ public:
 	virtual void UpdateCachedData();
 
 	//Used to check if track is different
-	IITTrack* m_Track;
+	long m_TrackID;
 
 	virtual void Pause();
 	virtual void Play();


### PR DESCRIPTION
Reduces CPU usage caused by updating song info more than needed.
Fixes where reconnecting to iTunes was broken when Apple removed the COM
events. iTunes currently has a bug where its CPU usage skyrockets when
attempting to close which can cause Rainmeter to hang for 3-5 seconds
while waiting on a response from iTunes. If Apple does not fix this in
the future we may need to move iTunes updates to its own thread to
prevent this issue.

I did not have a chance this weekend to separate this into its own thread. My next day off is Tuesday/Wednesday so I may look into that then.