### PR TITLE
AudioLevel now respect QUERY_TIMEOUT value

### DIFF
--- a/Plugins/PluginAudioLevel/PluginAudioLevel.cpp
+++ b/Plugins/PluginAudioLevel/PluginAudioLevel.cpp
@@ -534,7 +534,7 @@ PLUGIN_EXPORT double Update (void* data)
 	QueryPerformanceCounter(&pcCur);
 
 	// query the buffer
-	if (m->m_clCapture && pcCur.QuadPart-m->m_pcPoll.QuadPart * m->m_pcMult >= QUERY_TIMEOUT)
+	if (m->m_clCapture && (pcCur.QuadPart - m->m_pcPoll.QuadPart) * m->m_pcMult >= QUERY_TIMEOUT)
 	{
 		BYTE* buffer;
 		UINT32 nFrames;
@@ -728,7 +728,7 @@ PLUGIN_EXPORT double Update (void* data)
 							float fLog1 = m->m_bandFreq[iBand];
 							float x = (m->m_fftOut[iChan])[iBin];
 							float& y = (m->m_bandOut[iChan])[iBand];
-							
+
 							if(fLin1 <= fLog1)
 							{
 								y += (fLin1 - f0) * x * scalar;
@@ -779,7 +779,7 @@ PLUGIN_EXPORT double Update (void* data)
 		m->m_pcPoll = pcCur;
 
 	}
-	else if (!m->m_parent && !m->m_clCapture && pcCur.QuadPart - m->m_pcPoll.QuadPart * m->m_pcMult >= DEVICE_TIMEOUT)
+	else if (!m->m_parent && !m->m_clCapture && (pcCur.QuadPart - m->m_pcPoll.QuadPart) * m->m_pcMult >= DEVICE_TIMEOUT)
 	{
 		// poll for new devices
 		assert(m->m_enum);
@@ -1117,7 +1117,7 @@ HRESULT	Measure::DeviceInit ()
 		m_bandFreq = (float*)malloc(m_nBands * sizeof(float));
 		const double step = (log(m_freqMax / m_freqMin) / m_nBands) / log(2.0);
 		m_bandFreq[0] = (float)(m_freqMin * pow(2.0, step / 2.0));
-		
+
 		for (int iBand = 1; iBand < m_nBands; ++iBand)
 		{
 			m_bandFreq[iBand] = (float)(m_bandFreq[iBand - 1] * pow(2.0, step));


### PR DESCRIPTION
Hello, I was find a little bug that calculate the elapsed time in a wrong way
introduced in: https://github.com/rainmeter/rainmeter/commit/970ba451802abcdcc32b1f8babec11be0f3eed90#diff-4185f8f6cf84eaa5689aac3c8e5285a4