### PR TITLE
fix ilasm location finder

### DIFF
--- a/Build/DllExporter/Program.cs
+++ b/Build/DllExporter/Program.cs
@@ -175,7 +175,7 @@ namespace DllExporter
         {
             var arch = x64 ? DotNetFrameworkArchitecture.Bitness64 : DotNetFrameworkArchitecture.Bitness32;
             var path = ToolLocationHelper.GetPathToDotNetFrameworkFile(
-                "ilasm.exe", TargetDotNetFrameworkVersion.Version20, arch);
+                "ilasm.exe", TargetDotNetFrameworkVersion.VersionLatest, arch);
             return File.Exists(path) ? path : null;
         }
 


### PR DESCRIPTION
when not having .net framework 2.x vs will say ilasm not found, with fix it´s version independend.