### PR TITLE
Use HTTPS for IP Address Lookup

### DIFF
--- a/Build/Skins/illustro/Network/Network.ini
+++ b/Build/Skins/illustro/Network/Network.ini
@@ -40,7 +40,7 @@ MaxUpload=10485760
 ; For more information, go here: https://docs.rainmeter.net/tips/ipaddress
 Measure=Plugin
 Plugin=WebParser
-URL=http://checkip.amazonaws.com/
+URL=https://checkip.amazonaws.com/
 UpdateRate=14400
 RegExp=(?siU)^(.*)$
 StringIndex=1


### PR DESCRIPTION
Use HTTPS to ensure the response from `checkip.amazonaws.com` is delivered unmodified by a third-party.