### PR TITLE
Added usage monitor to Rainmeter

### DIFF
--- a/Build/Installer/Installer.nsi
+++ b/Build/Installer/Installer.nsi
@@ -727,6 +727,7 @@ Function HandlePlugins
 	${AndIf} $R7 != "RunCommand.dll"
 	${AndIf} $R7 != "SpeedFanPlugin.dll"
 	${AndIf} $R7 != "SysInfo.dll"
+	${AndIf} $R7 != "UsageMonitor.dll"
 	${AndIf} $R7 != "VirtualDesktops.dll"
 	${AndIf} $R7 != "WifiStatus.dll"
 	${AndIf} $R7 != "Win7AudioPlugin.dll"

--- a/Library/DialogInstall.cpp
+++ b/Library/DialogInstall.cpp
@@ -1156,6 +1156,7 @@ bool DialogInstall::IsIgnoredPlugin(const WCHAR* name)
 		L"RunCommand.dll",
 		L"SpeedFanPlugin.dll",
 		L"SysInfo.dll",
+		L"UsageMonitor.dll",
 		L"WebParser.dll",
 		L"WifiStatus.dll",
 		L"Win7AudioPlugin.dll",

--- a/Plugins/API/RainmeterAPI.cs
+++ b/Plugins/API/RainmeterAPI.cs
@@ -22,6 +22,11 @@ namespace Rainmeter
             m_Rm = rm;
         }
 
+        static public implicit operator API(IntPtr rm)
+        {
+            return new Rainmeter.API(rm);
+        }
+
         [DllImport("Rainmeter.dll", CharSet = CharSet.Unicode)]
         private extern static IntPtr RmReadString(IntPtr rm, string option, string defValue, bool replaceMeasures);
 
@@ -34,6 +39,23 @@ namespace Rainmeter
         [DllImport("Rainmeter.dll", CharSet = CharSet.Unicode)]
         private extern static IntPtr RmPathToAbsolute(IntPtr rm, string relativePath);
 
+        /// <summary>
+        /// Executes a command
+        /// </summary>
+        /// <param name="skin">Pointer to current skin (See API.GetSkin)</param>
+        /// <param name="command">Bang to execute</param>
+        /// <returns>No return type</returns>
+        /// <example>
+        /// <code>
+        /// [DllExport]
+        /// internal double Update(IntPtr data)
+        /// {
+        ///     Measure measure = (Measure)data;
+        ///     Rainmeter.API.Execute(measure->skin, "!SetVariable SomeVar 10");  // 'measure->skin' stored previously in the Initialize function
+        ///     return 0.0;
+        /// }
+        /// </code>
+        /// </example>
         [DllImport("Rainmeter.dll", EntryPoint = "RmExecute", CharSet = CharSet.Unicode)]
         public extern static void Execute(IntPtr skin, string command);
 
@@ -41,13 +63,10 @@ namespace Rainmeter
         private extern static IntPtr RmGet(IntPtr rm, RmGetType type);
 
         [DllImport("Rainmeter.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
-        private extern static int LSLog(LogType type, string unused, string message);
+        private extern static int LSLog(int type, string unused, string message);
 
         [DllImport("Rainmeter.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
         private extern static int RmLog(IntPtr rm, LogType type, string message);
-
-        [DllImport("Rainmeter.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
-        private extern static int RmLogF(IntPtr rm, LogType type, string format, params string[] message);
 
         private enum RmGetType
         {
@@ -75,10 +94,13 @@ namespace Rainmeter
         /// <returns>Returns the option value as a string</returns>
         /// <example>
         /// <code>
-        /// internal void Reload(Rainmeter.API rm, ref double maxValue)
+        /// [DllExport]
+        /// public static void Reload(IntPtr data, IntPtr rm, ref double maxValue)
         /// {
-        ///     string value = rm.ReadString("Value", "DefaultValue");
-        ///     string action = rm.ReadString("Action", "", false);  // [MeasureNames] will be parsed/replaced when the action is executed with RmExecute
+        ///     Measure measure = (Measure)data;
+        ///     Rainmeter.API api = (Rainmeter.API)rm;
+        ///     string value = api.ReadString("Value", "DefaultValue");
+        ///     string action = api.ReadString("Action", "", false);  // [MeasureNames] will be parsed/replaced when the action is executed with RmExecute
         /// }
         /// </code>
         /// </example>
@@ -95,9 +117,12 @@ namespace Rainmeter
         /// <returns>Returns the absolute path of the option value as a string</returns>
         /// <example>
         /// <code>
-        /// internal void Reload(Rainmeter.API rm, ref double maxValue)
+        /// [DllExport]
+        /// public static void Reload(IntPtr data, IntPtr rm, ref double maxValue)
         /// {
-        ///     string path = rm.ReadPath("MyPath", "C:\\");
+        ///     Measure measure = (Measure)data;
+        ///     Rainmeter.API api = (Rainmeter.API)rm;
+        ///     string path = api.ReadPath("MyPath", "C:\\");
         /// }
         /// </code>
         /// </example>
@@ -115,9 +140,12 @@ namespace Rainmeter
         /// <returns>Returns the option value as a double</returns>
         /// <example>
         /// <code>
-        /// internal void Reload(Rainmeter.API rm, ref double maxValue)
+        /// [DllExport]
+        /// public static void Reload(IntPtr data, IntPtr rm, ref double maxValue)
         /// {
-        ///     double value = rm.ReadDouble("Value", 20.0);
+        ///     Measure measure = (Measure)data;
+        ///     Rainmeter.API api = (Rainmeter.API)rm;
+        ///     double value = api.ReadDouble("Value", 20.0);
         /// }
         /// </code>
         /// </example>
@@ -135,9 +163,12 @@ namespace Rainmeter
         /// <returns>Returns the option value as an integer</returns>
         /// <example>
         /// <code>
-        /// internal void Reload(Rainmeter.API rm, ref double maxValue)
+        /// [DllExport]
+        /// public static void Reload(IntPtr data, IntPtr rm, ref double maxValue)
         /// {
-        ///     int value = rm.ReadInt("Value", 20);
+        ///     Measure measure = (Measure)data;
+        ///     Rainmeter.API api = (Rainmeter.API)rm;
+        ///     int value = api.ReadInt("Value", 20);
         /// }
         /// </code>
         /// </example>
@@ -153,9 +184,11 @@ namespace Rainmeter
         /// <returns>Returns a string replacing any variables in the 'str'</returns>
         /// <example>
         /// <code>
-        /// internal double Update()
+        /// [DllExport]
+        /// public static double Update(IntPtr data)
         /// {
-        ///     string myVar = ReplaceVariables("#MyVar#").ToUpperInvariant();
+        ///     Measure measure = (Measure)data;
+        ///     string myVar = measure.api.ReplaceVariables("#MyVar#").ToUpperInvariant(); // 'measure.api' stored previously in the Initialize function
         ///     if (myVar == "SOMETHING") { return 1.0; }
         ///     return 0.0;
         /// }
@@ -173,9 +206,13 @@ namespace Rainmeter
         /// <returns>Returns the current measure name as a string</returns>
         /// <example>
         /// <code>
-        /// internal void Initialize(Rainmeter.API rm)
+        /// [DllExport]
+        /// public static void Initialize(ref IntPtr data, IntPtr rm)
         /// {
-        ///     myName = GetMeasureName();  // declare 'myName' as a string in class scope
+        ///     Measure measure = new Measure();
+        ///     Rainmeter.API api = (Rainmeter.API)rm;
+        ///     measure.myName = api.GetMeasureName();  // declare 'myName' as a string in measure class
+        ///     data = GCHandle.ToIntPtr(GCHandle.Alloc(measure));
         /// }
         /// </code>
         /// </example>
@@ -191,9 +228,13 @@ namespace Rainmeter
         /// <returns>Returns an IntPtr to the current skin</returns>
         /// <example>
         /// <code>
-        /// internal void Initialize(Rainmeter.API rm)
+        /// [DllExport]
+        /// public static void Initialize(ref IntPtr data, IntPtr rm)
         /// {
-        ///     mySkin = GetSkin();  // declare 'mySkin' as a IntPtr in class scope
+        ///     Measure measure = new Measure();
+        ///     Rainmeter.API api = (Rainmeter.API)rm;
+        ///     measure.mySkin = api.GetSkin();  // declare 'mySkin' as a IntPtr in measure class
+        ///     data = GCHandle.ToIntPtr(GCHandle.Alloc(measure));
         /// }
         /// </code>
         /// </example>
@@ -203,21 +244,23 @@ namespace Rainmeter
         }
 
         /// <summary>
-        /// Retrieves a path to the Rainmeter data file (Rainmeter.data).
+        /// Retrieves a path to the Rainmeter data file (Rainmeter.data)
         /// </summary>
         /// <remarks>Call GetSettingsFile() in the Initialize function and store the results for later use</remarks>
         /// <returns>Returns the path and filename of the Rainmeter data file as a string</returns>
         /// <example>
         /// <code>
-        /// internal void Initialize(Rainmeter.API rm)
+        /// public static void Initialize(ref IntPtr data, IntPtr rm)
         /// {
-        ///     if (rmDataFile == null) { rmDataFile = GetSettingsFile(); }  // declare 'rmDataFile' as a string in global scope
+        ///     data = GCHandle.ToIntPtr(GCHandle.Alloc(new Measure()));
+        ///     Rainmeter.API api = (Rainmeter.API)rm;
+        ///     if (rmDataFile == null) { rmDataFile = API.GetSettingsFile(); }  // declare 'rmDataFile' as a string in global scope
         /// }
         /// </code>
         /// </example>
-        public string GetSettingsFile()
+        public static string GetSettingsFile()
         {
-            return Marshal.PtrToStringUni(RmGet(m_Rm, RmGetType.SettingsFile));
+            return Marshal.PtrToStringUni(RmGet(IntPtr.Zero, RmGetType.SettingsFile));
         }
 
         /// <summary>
@@ -227,9 +270,13 @@ namespace Rainmeter
         /// <returns>Returns the path and filename of the skin as a string</returns>
         /// <example>
         /// <code>
-        /// internal void Initialize(Rainmeter.API rm)
+        /// [DllExport]
+        /// public static void Initialize(ref IntPtr data, IntPtr rm)
         /// {
-        ///     skinName = GetSkinName(); }  // declare 'skinName' as a string in class scope
+        ///     Measure measure = new Measure();
+        ///     Rainmeter.API api = (Rainmeter.API)rm;
+        ///     measure.skinName = api.GetSkinName(); }  // declare 'skinName' as a string in measure class
+        ///     data = GCHandle.ToIntPtr(GCHandle.Alloc(measure));
         /// }
         /// </code>
         /// </example>
@@ -239,15 +286,40 @@ namespace Rainmeter
         }
 
         /// <summary>
+        /// Executes a command auto getting the skin reference
+        /// </summary>
+        /// <param name="command">Bang to execute</param>
+        /// <returns>No return type</returns>
+        /// <example>
+        /// <code>
+        /// [DllExport]
+        /// public static double Update(IntPtr data)
+        /// {
+        ///     Measure measure = (Measure)data;
+        ///     measure.api.Execute("!SetVariable SomeVar 10");  // 'measure.api' stored previously in the Initialize function
+        ///     return 0.0;
+        /// }
+        /// </code>
+        /// </example>
+        public void Execute(string command)
+        {
+            Execute(this.GetSkin(), command);
+        }
+
+        /// <summary>
         /// Returns a pointer to the handle of the skin window (HWND)
         /// </summary>
         /// <remarks>Call GetSkinWindow() in the Initialize function and store the results for later use</remarks>
         /// <returns>Returns a handle to the skin window as a IntPtr</returns>
         /// <example>
         /// <code>
+        /// [DllExport]
         /// internal void Initialize(Rainmeter.API rm)
         /// {
-        ///     skinWindow = GetSkinWindow(); }  // declare 'skinWindow' as a IntPtr in class scope
+        ///     Measure measure = new Measure();
+        ///     Rainmeter.API api = (Rainmeter.API)rm;
+        ///     measure.skinWindow = api.GetSkinWindow(); }  // declare 'skinWindow' as a IntPtr in measure class
+        ///     data = GCHandle.ToIntPtr(GCHandle.Alloc(measure));
         /// }
         /// </code>
         /// </example>
@@ -257,9 +329,9 @@ namespace Rainmeter
         }
 
         /// <summary>
-        /// DEPRECATED: Use Log(rm, type, message). Sends a message to the Rainmeter log.
+        /// DEPRECATED: Save your rm or api reference and use Log(rm, type, message). Sends a message to the Rainmeter log with no source.
         /// </summary>
-        public static void Log(LogType type, string message)
+        public static void Log(int type, string message)
         {
             LSLog(type, null, message);
         }
@@ -268,12 +340,13 @@ namespace Rainmeter
         /// Sends a message to the Rainmeter log with source
         /// </summary>
         /// <remarks>LOG_DEBUG messages are logged only when Rainmeter is in debug mode</remarks>
-        /// <param name="type">Log type (LOG_ERROR, LOG_WARNING, LOG_NOTICE, or LOG_DEBUG)</param>
+        /// <param name="rm">Pointer to the plugin measure</param>
+        /// <param name="type">Log type, use API.LogType enum (Error, Warning, Notice, or Debug)</param>
         /// <param name="message">Message to be logged</param>
         /// <returns>No return type</returns>
         /// <example>
         /// <code>
-        /// Log(rm, LOG_NOTICE, "I am a 'notice' log message with a source");
+        /// Rainmeter.API.Log(rm, API.LogType.Notice, "I am a 'notice' log message with a source");
         /// </code>
         /// </example>
         public static void Log(IntPtr rm, LogType type, string message)
@@ -282,26 +355,83 @@ namespace Rainmeter
         }
 
         /// <summary>
+        /// <summary>
         /// Sends a formatted message to the Rainmeter log
         /// </summary>
         /// <remarks>LOG_DEBUG messages are logged only when Rainmeter is in debug mode</remarks>
         /// <param name="rm">Pointer to the plugin measure</param>
-        /// <param name="level">Log level (LOG_ERROR, LOG_WARNING, LOG_NOTICE, or LOG_DEBUG)</param>
-        /// <param name="format">Formatted message to be logged, follows printf syntax</param>
+        /// <param name="type">Log type, use API.LogType enum (Error, Warning, Notice, or Debug)</param>
+        /// <param name="format">Formatted message to be logged, follows string.Format syntax</param>
         /// <param name="args">Comma separated list of args referenced in the formatted message</param>
         /// <returns>No return type</returns>
         /// <example>
         /// <code>
-        /// string notice = "notice";
-        /// LogF(rm, LOG_NOTICE, "I am a '%s' log message with a source", notice);
+        /// [DllExport]
+        /// public static double Update(IntPtr data)
+        /// {
+        ///     Measure measure = (Measure)data;
+        ///     string notice = "notice";
+        ///     measure.api.LogF(measure.rm, API.LogType.Notice, "I am a '{0}' log message with a source", notice); // 'measure.rm' stored previously in the Initialize function
+        ///     
+        ///     return 0.0;
+        /// }
         /// </code>
         /// </example>
-        public static void LogF(IntPtr rm, LogType type, string format, params string[] args)
+        public static void LogF(IntPtr rm, LogType type, string format, params Object[] args)
         {
-            RmLogF(rm, type, format, args);
+            RmLog(rm, type, string.Format(format, args));
+        }
+
+        /// <summary>
+        /// Sends a message to the Rainmeter log with source
+        /// </summary>
+        /// <remarks>LOG_DEBUG messages are logged only when Rainmeter is in debug mode</remarks>
+        /// <param name="type">Log type, use API.LogType enum (Error, Warning, Notice, or Debug)</param>
+        /// <param name="message">Message to be logged</param>
+        /// <returns>No return type</returns>
+        /// <example>
+        /// <code>
+        /// [DllExport]
+        /// public static double Update(IntPtr data)
+        /// {
+        ///     Measure measure = (Measure)data;
+        ///     measure.api.Log(api, API.LogType.Notice, "I am a 'notice' log message with a source"); // 'measure.api' stored previously in the Initialize function
+        ///     
+        ///     return 0.0;
+        /// }
+        /// </code>
+        /// </example>
+        public void Log(LogType type, string message)
+        {
+            RmLog(this.m_Rm, type, message);
+        }
+
+        /// <summary>
+        /// Sends a formatted message to the Rainmeter log
+        /// </summary>
+        /// <remarks>LOG_DEBUG messages are logged only when Rainmeter is in debug mode</remarks>
+        /// <param name="type">Log type, use API.LogType enum (Error, Warning, Notice, or Debug)</param>
+        /// <param name="format">Formatted message to be logged, follows string.Format syntax</param>
+        /// <param name="args">Comma separated list of args referenced in the formatted message</param>
+        /// <returns>No return type</returns>
+        /// <example>
+        /// <code>
+        /// [DllExport]
+        /// public static double Update(IntPtr data)
+        /// {
+        ///     Measure measure = (Measure)data;
+        ///     string notice = "notice";
+        ///     measure.api.LogF(API.LogType.Notice, "I am a '{0}' log message with a source", notice); // 'measure.api' stored previously in the Initialize function
+        ///     
+        ///     return 0.0;
+        /// }
+        /// </code>
+        /// </example>
+        public void LogF(LogType type, string format, params Object[] args)
+        {
+            RmLog(this.m_Rm, type, string.Format(format, args));
         }
     }
-
     /// <summary>
     /// Dummy attribute to mark method as exported for DllExporter.exe.
     /// </summary>
@@ -310,6 +440,7 @@ namespace Rainmeter
     {
         public DllExport()
         {
+
         }
     }
 }

--- a/Plugins/API/RainmeterAPI.h
+++ b/Plugins/API/RainmeterAPI.h
@@ -146,6 +146,7 @@ enum RmGetType
 /// Sends a message to the Rainmeter log with source
 /// </summary>
 /// <remarks>LOG_DEBUG messages are logged only when Rainmeter is in debug mode</remarks>
+/// <param name="rm">Pointer to the plugin measure</param>
 /// <param name="type">Log type (LOG_ERROR, LOG_WARNING, LOG_NOTICE, or LOG_DEBUG)</param>
 /// <param name="message">Message to be logged</param>
 /// <returns>No return type</returns>
@@ -249,7 +250,7 @@ __inline double RmReadDouble(void* rm, LPCWSTR option, double defValue)
 /// <summary>
 /// Retrieves the name of the measure
 /// </summary>
-/// <remarks>Call GetMeasureName() in the Initialize function and store the results for later use</remarks>
+/// <remarks>Call RmGetMeasureName() in the Initialize function and store the results for later use</remarks>
 /// <param name="rm">Pointer to the plugin measure</param>
 /// <returns>Returns the current measure name as a string (LPCWSTR)</returns>
 /// <example>
@@ -276,7 +277,9 @@ __inline LPCWSTR RmGetMeasureName(void* rm)
 /// <code>
 /// PLUGIN_EXPORT void Initialize(void** data, void* rm)
 /// {
-/// 	if (rmDataFile == nullptr) { rmDataFile = RmGetSettingsFile(); }  // 'rmDataFile' defined as a string (LPCWSTR) in global scope
+/// 	Measure* measure = new Measure;
+/// 	*data = measure;
+///		if (rmDataFile == nullptr) { rmDataFile = RmGetSettingsFile(); }  // 'rmDataFile' defined as a string (LPCWSTR) in global scope
 /// }
 /// </code>
 /// </example>
@@ -310,6 +313,7 @@ __inline void* RmGetSkin(void* rm)
 /// Retrieves full path and name of the skin
 /// </summary>
 /// <remarks>Call GetSkinName() in the Initialize function and store the results for later use</remarks>
+/// <param name="rm">Pointer to the plugin measure</param>
 /// <returns>Returns the path and filename of the skin as a string (LPCWSTR)</returns>
 /// <example>
 /// <code>
@@ -330,6 +334,7 @@ __inline LPCWSTR RmGetSkinName(void* rm)
 /// Returns a pointer to the handle of the skin window (HWND)
 /// </summary>
 /// <remarks>Call GetSkinWindow() in the Initialize function and store the results for later use</remarks>
+/// <param name="rm">Pointer to the plugin measure</param>
 /// <returns>Returns a handle to the skin window as a HWND</returns>
 /// <example>
 /// <code>

--- a/Plugins/PluginInputText/Main.cs
+++ b/Plugins/PluginInputText/Main.cs
@@ -71,7 +71,7 @@ namespace InputText
                         }
                         catch (Exception ex)
                         {
-                            API.Log(API.LogType.Error, "C# plugin in ExecuteBang(), " + ex.GetType().ToString() + ": " + ex.Message);
+                            rm.Log(API.LogType.Error, "C# plugin in ExecuteBang(), " + ex.GetType().ToString() + ": " + ex.Message);
                         }
 
                         lock (this.locker)

--- a/Plugins/PluginInputText/PluginCode.cs
+++ b/Plugins/PluginInputText/PluginCode.cs
@@ -161,7 +161,7 @@ namespace InputText
 
             // Unhandled command, log the message but otherwise do nothing
             param.Type = ExecuteBangParam.BangType.Unknown;
-            API.Log(API.LogType.Debug, "InputText: Received command \"" + sParts[0].Trim() + "\", left unhandled");
+            rm.Log(API.LogType.Debug, "InputText: Received command \"" + sParts[0].Trim() + "\", left unhandled");
 
             return false;
         }
@@ -240,7 +240,7 @@ namespace InputText
                 catch (Exception ex)
                 {
                     // If there was an error doing any of the above, log it for debugging purposes.
-                    API.Log(API.LogType.Warning, "InputText: Exception " + ex.GetType().ToString() + ": " + ex.Message);
+                    rm.Log(API.LogType.Warning, "InputText: Exception " + ex.GetType().ToString() + ": " + ex.Message);
                     return false;
                 }
             }

--- a/Plugins/PluginInputText/Rainmeter.cs
+++ b/Plugins/PluginInputText/Rainmeter.cs
@@ -85,7 +85,7 @@ namespace InputText
             }
             else
             {
-                API.Log(API.LogType.Error,
+                rm.Log(API.LogType.Error,
                     "Rainmeter told us the HWND for window '" + this._SkinName + "' is " + this._Handle.ToInt32().ToString() + "L, but couldn't receive a proper RECT from it");
             }
 

--- a/Plugins/PluginUsageMonitor/AssemblyInfo.cs
+++ b/Plugins/PluginUsageMonitor/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+[assembly: AssemblyCopyright("© 2018 - Trevor Hamilton")]
+[assembly: AssemblyVersion("0.9.9")]
+
+// Do not change the entries below!
+#if X64
+[assembly: AssemblyInformationalVersion("3.0.2.2161 (64-bit)")]
+#else
+[assembly: AssemblyInformationalVersion("3.0.2.2161 (32-bit)")]
+#endif
+[assembly: AssemblyProduct("Rainmeter")]

--- a/Plugins/PluginUsageMonitor/PluginUsageMonitor.csproj
+++ b/Plugins/PluginUsageMonitor/PluginUsageMonitor.csproj
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{8B710F76-69EA-4803-9F0A-9DAABE563CF1}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>PluginUsageMonitor</RootNamespace>
+    <AssemblyName>UsageMonitor</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <OldToolsVersion>3.5</OldToolsVersion>
+    <UpgradeBackupLocation />
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>x32\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <NoWarn>1607</NoWarn>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>x32\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <NoWarn>1607</NoWarn>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>x64\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;X64</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <NoWarn>1607</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>x64\Release\</OutputPath>
+    <DefineConstants>TRACE;X64</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>none</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <NoWarn>1607</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="UsageMonitor.cs" />
+    <Compile Include="$(SolutionDir)Version.cs" />
+    <Compile Include="$(SolutionDir)Plugins\API\RainmeterAPI.cs" />
+  </ItemGroup>
+  <Import Project="$(SolutionDir)Build\VS\RainmeterPlugin.Cs.props" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <PropertyGroup>
+    <PostBuildEvent>"$(RmOutDirRoot)Tools\DllExporter.exe" "$(ConfigurationName)" "$(PlatformName)" "$(TargetDir)\" "$(TargetFileName)"</PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/Plugins/PluginUsageMonitor/PluginUsageMonitor.sln
+++ b/Plugins/PluginUsageMonitor/PluginUsageMonitor.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2026
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UsageMonitor", "UsageMonitor.csproj", "{8B710F76-69EA-4803-9F0A-9DAABE563CF1}"
+EndProject
+Global
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
+	EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8B710F76-69EA-4803-9F0A-9DAABE563CF1}.Debug|x64.ActiveCfg = Debug|x64
+		{8B710F76-69EA-4803-9F0A-9DAABE563CF1}.Debug|x64.Build.0 = Debug|x64
+		{8B710F76-69EA-4803-9F0A-9DAABE563CF1}.Debug|x86.ActiveCfg = Debug|x86
+		{8B710F76-69EA-4803-9F0A-9DAABE563CF1}.Debug|x86.Build.0 = Debug|x86
+		{8B710F76-69EA-4803-9F0A-9DAABE563CF1}.Release|x64.ActiveCfg = Release|x64
+		{8B710F76-69EA-4803-9F0A-9DAABE563CF1}.Release|x64.Build.0 = Release|x64
+		{8B710F76-69EA-4803-9F0A-9DAABE563CF1}.Release|x86.ActiveCfg = Release|x86
+		{8B710F76-69EA-4803-9F0A-9DAABE563CF1}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8DD79F8B-EFA1-4FF4-8870-C650E89302B9}
+	EndGlobalSection
+EndGlobal

--- a/Plugins/PluginUsageMonitor/UsageMonitor.cs
+++ b/Plugins/PluginUsageMonitor/UsageMonitor.cs
@@ -1,0 +1,1100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Rainmeter;
+
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+
+namespace UsageMonitor
+{
+    //These are the supported aliases, these are used to make it easier for skins to just get a specific category
+    //Note that Netdown & Netup are unimplemented
+    public enum MeasureAlias
+    {
+        CPU,
+        RAM,
+        RAMSHARED,
+        IO,
+        IOREAD,
+        IOWRITE,
+        GPU,
+        VRAM,
+        VRAMSHARED,
+        NETDOWN,
+        NETUP,
+        CUSTOM
+    }
+    //Types of blocklists
+    public enum BlockType
+    {
+        N, //No blocking
+        B, //Blacklist
+        W //Whitelist
+    }
+    //Contains all the options for the measure
+    public class MeasureOptions
+    {
+        public API API;
+        public MeasureOptions(API API)
+        {
+            this.API = API;
+        }
+
+        //One of these will normally be empty/0
+        public int Index;
+        public String Name;
+
+        //These are all the default values of the options (Some are overiden for certain aliases)
+        public bool IsRawValue = false;
+        public bool IsPercent = false;
+        public bool IsPID = false;
+        public bool IsRollup = true;
+        public BlockType BlockType { get; private set; } = BlockType.B;
+        public HashSet<String> BlockList { get; private set; } = new HashSet<string> { "_Total", "Idle" };
+        //This is the key that is used to identify if a blocklist can be shared, it is the options rollup status, blocktype, and list
+        public String BlockString { get; private set; } = true.ToString() + BlockType.B + "|" + String.Join(",", new List<string> { "_Total", "Idle" }.ToArray());
+        public void UpdateBlockList(BlockType blockType, HashSet<String> blockList)
+        {
+            this.BlockType = blockType;
+            this.BlockList = blockList;
+            this.BlockString = IsRollup.ToString() + this.BlockType + "|" + String.Join(",", this.BlockList.ToArray());
+        }
+        public void UpdateBlockList(BlockType blockType, String blockList)
+        {
+            this.BlockType = blockType;
+            this.BlockList = new HashSet<string>(blockList.Split(',').Select(p => p.Trim()));
+            this.BlockString = IsRollup.ToString() + this.BlockType + "|" + blockList;
+        }
+
+        //Update rate will be by default 1 second as that is the fastest PerfMon updates
+        public int UpdateInMS = 1000;
+
+        //Used to identify the measure that had this option group
+        public string ID;
+        public String Category;
+        public String Counter;
+        //These are the original info before translation, if we detect that a specific category or counter does not exist we will try using these instead
+        //These are null if there was no translation applied
+        public String UntranslatedCategory = "";
+        public String UntranslatedCounter = "";
+
+        //Takes an alias and changes the options to be ideal for that alias
+        //@TODO add NETUP and NETDOWN support
+        public void DeAlias(MeasureAlias alias)
+        {
+            if (alias == MeasureAlias.CPU)
+            {
+                this.Category = "Process";
+                this.Counter = "% Processor Time";
+                this.IsPercent = true;
+            }
+            else if (alias == MeasureAlias.RAM)
+            {
+                this.Category = "Process";
+                this.Counter = "Working Set - Private";
+            }
+            else if (alias == MeasureAlias.RAMSHARED)
+            {
+                this.Category = "Process";
+                this.Counter = "Working Set";
+            }
+            else if (alias == MeasureAlias.IO)
+            {
+                this.Category = "Process";
+                this.Counter = "IO Data Bytes/sec";
+            }
+            else if (alias == MeasureAlias.IOREAD)
+            {
+                this.Category = "Process";
+                this.Counter = "IO Read Bytes/sec";
+            }
+            else if (alias == MeasureAlias.IOWRITE)
+            {
+                this.Category = "Process";
+                this.Counter = "IO Write Bytes/sec";
+            }
+            else if (alias == MeasureAlias.GPU)
+            {
+                this.Category = "GPU Engine";
+                this.Counter = "Utilization Percentage";
+                this.IsPID = true;
+            }
+            else if (alias == MeasureAlias.VRAM)
+            {
+                this.Category = "GPU Process Memory";
+                this.Counter = "Dedicated Usage";
+                this.IsPID = true;
+            }
+            else if (alias == MeasureAlias.VRAMSHARED)
+            {
+                this.Category = "GPU Process Memory";
+                this.Counter = "Shared Usage";
+                this.IsPID = true;
+            }
+        }
+    }
+
+    //Custom instance that implements IComparable so that it can be easily sorted
+    public class Instance : IComparable<Instance>
+    {
+
+        public String Name;
+        public double Value;
+        public CounterSample Sample;
+
+        public Instance(String Name, double Value, CounterSample Sample)
+        {
+            this.Name = Name;
+            this.Value = Value;
+            this.Sample = Sample;
+        }
+
+        public int CompareTo(Instance that)
+        {
+            if (this.Value > that.Value) return -1;
+            if (this.Value < that.Value) return 1;
+
+            //Try looking at raw values instead to break ties in the event of a tie
+            if (this.Sample.RawValue > that.Sample.RawValue) return -1;
+            if (this.Sample.RawValue < that.Sample.RawValue) return 1;
+
+            return 0;
+        }
+    }
+    
+    //This class handles taking a measures options and turning it in to an organized list of performance categories that it then keeps up to date
+    //It is highly scalable and multithreaded and will share as many resources as possible between measures
+    //Resouce sharing is reduced slightly when two measures dont share the same block list, even more when they are not the same rollup state
+    //Minimal resources are shared between measures with different categories and each category will run on its own thread
+    public static class Categories
+    {
+        //This holds all the categories we are monitoring, when one stops being monitored it will be removed from the dictionary
+        //Each category in here will be updated on its own thread
+        private static Dictionary<String, Counters> CategoriesCounters = new Dictionary<String, Counters>(sizeof(MeasureAlias));
+
+        //Used for the timer info since .Net 3.5 does not have tuples
+        //@TODO merge the timer class and timer variables to be part of the same class within CategoryLists
+        public struct TimerInfo
+        {
+            public String ID;
+            public int Rate;
+            public TimerInfo(String ID, int Rate)
+            {
+                this.ID = ID;
+                this.Rate = Rate;
+            }
+        }
+
+        private class Counters
+        {
+            //Locks data from being read when 
+            private Object dataLock = new Object();
+
+            //This class is mainly just to tidy things up while building the lists that end up being exposed
+            private class CounterInfo
+            {
+                //Key for ByName will be the rollup status of the instaces, with the value being the dictionary of the instances by name
+                public Dictionary<bool, Dictionary<String, Instance>> ByName;
+                //Key for ByName will be the blocklist of the instaces, with the value being a list of the instances sorted by value
+                public Dictionary<string, List<Instance>> ByUsage;
+                //Key for _Sum will be the blocklist of the instaces, with the value being the sum of that lists value
+                //I could pack this into the ByUsage list but it seemed pointless
+                public Dictionary<string, double> Sum;
+                public CounterInfo(int count)
+                {
+                    //Key is roll up state as two dictionaries of names can not be shared if they are rolled up differently as they have different values
+                    //NOTE: ByName contains everything, even if it would have been ignored by the blocklist
+                    this.ByName = new Dictionary<bool, Dictionary<string, Instance>>(count);
+
+                    //Key is block string as the list/sum can not be shared if they contain different instances
+                    this.ByUsage = new Dictionary<string, List<Instance>>(count);
+                    this.Sum = new Dictionary<string, double>(count);
+                }
+            }
+
+            //This is the collection of all the counters and their instances in formatted collection organized by different possible options
+            //Key is the name of the counter, with the value being the all the info for the measures using that counter
+            private Dictionary<String, CounterInfo> CountersInfo;
+            //This is the collection of all the counters and the options from the measures referencing it
+            //Key is the specific counter with its value being the ID of the measure that gave us the option set and the option set itself
+            //@TODO Merge this into CounterInfo class
+            private Dictionary<String, Dictionary<String, MeasureOptions>> CounterOptions;
+
+            //These control the thread in change of updating categories, its update its update rate dynamically adjust based on lowest rate currently active
+            private Timer UpdateTimer;
+            private TimerInfo UpdateTimerInfo = new TimerInfo("", int.MaxValue);
+            private Object UpdateTimerLock = new Object();
+
+
+            //Function used to update all info for given category
+            //Will format the info then based on current option sets that are using that category
+            private void UpdateCategory(String category)
+            {
+                if (Monitor.TryEnter(UpdateTimerLock))
+                {
+                    try
+                    {
+                        //This is the most expensive part accounting for a very large amount of the CPU, this is avoided at all costs
+                        //Avoiding doing this is why this is why this loop is so complex
+                        InstanceDataCollectionCollection currCategoryData = new PerformanceCounterCategory(category).ReadCategory();
+
+                        //This will be our collection of counters for this category, we will build in this temp collection before changing the pointer at the end
+                        Dictionary<String, CounterInfo> tempCounters = new Dictionary<string, CounterInfo>(this.CounterOptions.Count());
+
+                        //Loop through each counter
+                        foreach (var currCounter in this.CounterOptions)
+                        {
+                            //All the instances for this counter unformatted from PerfMon
+                            InstanceDataCollection counterInstances = currCategoryData[currCounter.Key];
+                            //Temp counter info collecetions that we will build on in the option set loop
+                            CounterInfo tempCounterInfo = new CounterInfo(currCounter.Value.Count());
+
+                            //Loop through each option set for the current counter
+                            foreach (var options in currCounter.Value.Values)
+                            {
+                                //Instances will be added to these collections before being added to tempCounterInfo under the collection with the same name
+                                //They will be added to their collection with a key of what type of option it was formatted under
+                                Dictionary<String, Instance> tempByName;
+                                List<Instance> tempByUsage;
+                                double tempSum = 0;
+
+                                //If counter did not exist for this category
+                                if (counterInstances == null)
+                                {
+                                    //Throw and error and add nothing to the temp collections
+                                    options.API.Log(API.LogType.Debug, "Could not find a counter in category " + category + " called " + currCounter.Key);
+
+                                    //If we are using a translation and this happens try it untranslated
+                                    if(options.UntranslatedCounter.Count() > 0)
+                                    {
+                                        options.Counter = options.UntranslatedCounter;
+                                        options.UntranslatedCounter = "";
+                                    }
+                                }
+                                //If there is already an ByName list that can be shared with this option set start from that
+                                else if (tempCounterInfo.ByName.TryGetValue(options.IsRollup, out tempByName))
+                                {
+                                    //If there is not already a ByUsage list that can be shared with this option set then calculate a new one from ByName
+                                    if (!tempCounterInfo.ByUsage.TryGetValue(options.BlockString, out tempByUsage))
+                                    {
+                                        tempByUsage = new List<Instance>();
+
+                                        //Generate a new ByUsage list that complies with this option set's blocklist
+                                        foreach (var instance in tempByName.Values.ToList())
+                                        {
+                                            //Check that either item is not in the blacklist or is in the whitelist
+                                            if ((options.BlockType == BlockType.N)
+                                                || (options.BlockType == BlockType.B && !options.BlockList.Contains(instance.Name))
+                                                || (options.BlockType == BlockType.W && options.BlockList.Contains(instance.Name)))
+                                            {
+                                                tempByUsage.Add(instance);
+                                                tempSum += instance.Value;
+                                            }
+                                        }
+                                        tempByUsage.Sort();
+
+                                        //Add to temp collection as we are done
+                                        tempCounterInfo.ByUsage.Add(options.BlockString, tempByUsage);
+                                        tempCounterInfo.Sum.Add(options.BlockString, tempSum);
+                                    }
+                                    //If there was then we are done as nothing more needs done
+                                }
+                                //If there was not already an ByName list that could be shared start for scratch
+                                else
+                                {
+                                    tempByName = new Dictionary<string, Instance>(counterInstances.Count);
+                                    bool hasLastUpdate = this.CountersInfo.TryGetValue(currCounter.Key, out CounterInfo lastInfo);
+
+                                    //Go through each instance and format the data for use with Rainmeter such as PID translation & interpreting raw values
+                                    foreach (InstanceData instanceData in counterInstances.Values)
+                                    {
+                                        Instance instance = new Instance(instanceData.InstanceName, instanceData.RawValue, instanceData.Sample);
+
+                                        //Instance name is a PID and needs to be converted to a process name
+                                        //NOTE: If we found we needed to translate different looking PIDs then that would go here
+                                        if (options.IsPID)
+                                        {
+                                            //This could be more hard coded but I wanted to be more versitile;
+                                            int start = instance.Name.IndexOf("pid_") + "pid_".Length;
+                                            int end = instance.Name.IndexOf("_", start);
+
+                                            if (Int32.TryParse(instance.Name.Substring(start, end - start), out int myPid))
+                                            {
+                                                try
+                                                {
+                                                    //PIDs will not be interpreted if there is no info to go on and will be left as is
+                                                    if (pids.Count > 0)
+                                                    {
+                                                        instance.Name = pids[myPid];
+                                                    }
+                                                }
+                                                catch
+                                                {
+                                                    options.API.Log(API.LogType.Debug, "Could not find a process with PID of " + myPid + " this PID will be ignored till found");
+                                                    continue;
+                                                }
+                                            }
+                                        }
+
+                                        //If we are rolling up similar names then take the last # in the name and remove all after it
+                                        //NOTE: If we wanted to add another way to rollup names it would go here
+                                        if (options.IsRollup)
+                                        {
+                                            int index = instance.Name.LastIndexOf('#');
+                                            if (index > 0)
+                                            {
+                                                instance.Name = instance.Name.Substring(0, index);
+                                            }
+                                        }
+
+                                        //Check if we already have a instance with the same name, if we do combine the two now
+                                        if (tempByName.TryGetValue(instance.Name, out Instance mergedInstance))
+                                        {
+                                            instance.Value += mergedInstance.Value;
+                                            instance.Sample = new CounterSample(mergedInstance.Sample.RawValue + instance.Sample.RawValue,
+                                                mergedInstance.Sample.BaseValue, mergedInstance.Sample.CounterFrequency,
+                                                mergedInstance.Sample.SystemFrequency, mergedInstance.Sample.TimeStamp,
+                                                mergedInstance.Sample.TimeStamp100nSec, mergedInstance.Sample.CounterType);
+                                        }
+
+                                        //If there is a valid last update value and the current is value process the value to be readable
+                                        //If there is not then set the value to 0
+                                        if (hasLastUpdate && lastInfo.ByName.TryGetValue(options.IsRollup, out Dictionary<string, Instance> lastMeasure)
+                                            && lastMeasure.TryGetValue(instance.Name, out Instance lastInstance))
+                                        {
+                                            if (lastInstance.Sample.RawValue != 0 && instance.Sample.RawValue != 0)
+                                            {
+                                                instance.Value = CounterSample.Calculate(lastInstance.Sample, instance.Sample);
+                                            }
+                                            else
+                                            {
+                                                instance.Value = 0;
+                                            }
+                                        }
+                                        else
+                                        {
+                                            instance.Value = 0;
+                                        }
+
+                                        //Since instance is human readable at this point go on ahead and either update the old value or add the value to the collection
+                                        if (mergedInstance == null)
+                                        {
+                                            tempByName.Add(instance.Name, instance);
+                                        }
+                                        else
+                                        {
+                                            tempByName[mergedInstance.Name] = instance;
+                                        }
+                                    }
+                                    tempByUsage = new List<Instance>();
+
+                                    //Generate a ByUsage list that complies with this option set's blocklist
+                                    foreach (var instance in tempByName.Values.ToList())
+                                    {
+                                        //Check that either item is not in the blacklist or is in the whitelist
+                                        if ((options.BlockType == BlockType.N)
+                                            || (options.BlockType == BlockType.B && !options.BlockList.Contains(instance.Name))
+                                            || (options.BlockType == BlockType.W && options.BlockList.Contains(instance.Name)))
+                                        {
+                                            tempByUsage.Add(instance);
+                                            tempSum += instance.Value;
+                                        }
+                                    }
+                                    tempByUsage.Sort();
+
+                                    //Add to temp collection as we are done
+                                    tempCounterInfo.ByName.Add(options.IsRollup, tempByName);
+                                    tempCounterInfo.ByUsage.Add(options.BlockString, tempByUsage);
+                                    tempCounterInfo.Sum.Add(options.BlockString, tempSum);
+                                }
+                            }
+
+                            //Add newly formatted counter collections to the collection of counters
+                            tempCounters.Add(currCounter.Key, tempCounterInfo);
+                        }
+
+                        //Make tempCounter the current counter list
+                        lock (dataLock)
+                        {
+                            CountersInfo = tempCounters;
+                        }
+                    }
+                    catch(InvalidOperationException)
+                    {
+                        API api = this.CounterOptions.FirstOrDefault().Value.FirstOrDefault().Value.API;
+
+                        if (api != null)
+                        {
+                            api.Log(API.LogType.Debug, "Could not find a category called " + category);
+                        }
+                        else
+                        {
+                            API.Log((int)API.LogType.Debug, "Could not find a category called " + category);
+                        }
+                        //Do not worry if using a translation since categories must be unique
+                    }
+                    catch
+                    {
+                        API.Log((int)API.LogType.Error, "UsageMonitor crashed trying to update the counters");
+                    }
+                    finally
+                    {
+                        Monitor.Exit(UpdateTimerLock);
+                    }
+                }
+            }
+
+            //Constructor for the counters object, assumes all counters added to this object are within the same category
+            public Counters(MeasureOptions options)
+            {
+                this.CountersInfo = new Dictionary<string, CounterInfo>();
+                this.CounterOptions = new Dictionary<string, Dictionary<String, MeasureOptions>> { { options.Counter, new Dictionary<string, MeasureOptions> { { options.ID, options } } } };
+
+                if (options.IsPID)
+                {
+                    pidIDs.Add(options.ID, options.UpdateInMS);
+
+                    if (pidUpdateTimer == null || pidUpdateTimerInfo.Rate > options.UpdateInMS)
+                    {
+                        pidUpdateTimerInfo = new TimerInfo(options.ID, options.UpdateInMS);
+                        pidUpdateTimer = new Timer((stateInfo) => UpdatePIDs(), null, 0, pidUpdateTimerInfo.Rate);
+                    }
+                }
+
+                this.UpdateTimerInfo = new TimerInfo(options.ID, options.UpdateInMS);
+                this.UpdateTimer = new Timer((stateInfo) => UpdateCategory(options.Category), null, 0, this.UpdateTimerInfo.Rate);
+            }
+
+            //Add new counter to monitor (Assumes added to counters object with same category)
+            //Will also change update rate if new one is lower
+            public void AddCounter(MeasureOptions options)
+            {
+                //If we are not already updating add the counter
+                if (Monitor.TryEnter(UpdateTimerLock))
+                {
+                    try
+                    {
+                        UnsafeAddCounter(options);
+                    }
+                    finally
+                    {
+                        Monitor.Exit(UpdateTimerLock);
+                    }
+                }
+                else
+                {
+                    //Start a new thread and forget about it
+                    new Thread(() =>
+                    {
+                        lock (UpdateTimerLock)
+                        {
+                            UnsafeAddCounter(options);
+                        }
+                    }).Start();
+                }
+            }
+            private void UnsafeAddCounter(MeasureOptions options)
+            {
+                //If counter is already being monitored
+                if (this.CounterOptions.TryGetValue(options.Counter, out Dictionary<String, MeasureOptions> counter))
+                {
+                    //If measure was already used and just needs values updated
+                    if (counter.TryGetValue(options.ID, out MeasureOptions tempOptions))
+                    {
+                        //@TODO this is was more complex than just an update because what if category or PerfMon counter changes
+                        //      thus there needs to be safeguards against that either here or more likely in the plugin counter
+                        tempOptions = options;
+                    }
+                    else
+                    {
+                        counter.Add(options.ID, options);
+                    }
+                }
+                //If counter is not being monitored
+                else
+                {
+                    CounterOptions.Add(options.Counter, new Dictionary<string, MeasureOptions> { { options.ID, options } });
+                }
+
+                if (this.UpdateTimerInfo.Rate > options.UpdateInMS)
+                {
+                    this.UpdateTimerInfo = new TimerInfo(options.ID, options.UpdateInMS);
+                    this.UpdateTimer.Change(5, this.UpdateTimerInfo.Rate);
+                }
+
+                if (options.IsPID)
+                {
+                    pidIDs.Add(options.ID, options.UpdateInMS);
+
+                    if (pidUpdateTimer == null || pidUpdateTimerInfo.Rate > options.UpdateInMS)
+                    {
+                        pidUpdateTimerInfo = new TimerInfo(options.ID, options.UpdateInMS);
+                        pidUpdateTimer = new Timer((stateInfo) => UpdatePIDs(), null, 0, pidUpdateTimerInfo.Rate);
+                    }
+                }
+            }
+            //Removes a a reference to a given counter (Counter is only removed if it is the last reference to that counter) 
+            //Will also change update rate if the one removed was the last one with that update rate
+            public void RemoveCounter(MeasureOptions options)
+            {
+                if (Monitor.TryEnter(UpdateTimerLock))
+                {
+                    try
+                    {
+                        UnsafeRemoveCounter(options);
+                    }
+                    finally
+                    {
+                        Monitor.Exit(UpdateTimerLock);
+                    }
+                }
+                else
+                {
+                    lock (UpdateTimerLock)
+                    {
+                        UnsafeRemoveCounter(options);
+                    }
+                }
+            }
+            //This uses no locks and does
+            private void UnsafeRemoveCounter(MeasureOptions options)
+            {
+                //If category that needs to be removed exists
+                if (this.CounterOptions.TryGetValue(options.Counter, out Dictionary<String, MeasureOptions> counter))
+                {
+                    //If measure options are removed
+                    if (counter.Remove(options.ID))
+                    {
+                        //If no more measures exist with this category remove it
+                        if (counter.Count() == 0)
+                        {
+                            this.CounterOptions.Remove(options.Counter);
+                        }
+
+
+                        if (options.IsPID && pidIDs.Remove(options.ID))
+                        {
+                            //If nothing needs PID update stop thread
+                            if (pidIDs.Count == 0)
+                            {
+                                pidUpdateTimer.Dispose();
+                                pidUpdateTimer = null;
+                                pidUpdateTimerInfo = new TimerInfo("", int.MaxValue);
+                            }
+                            else if (pidUpdateTimerInfo.ID == options.ID)
+                            {
+                                bool timerUpdated = false;
+                                TimerInfo newTimerInfo = new TimerInfo("", int.MaxValue);
+                                foreach (var tempCounter in this.CounterOptions.Values)
+                                {
+                                    foreach (var tempOptions in tempCounter.Values)
+                                    {
+                                        if (tempOptions.ID != options.ID)
+                                        {
+                                            if (tempOptions.UpdateInMS == pidUpdateTimerInfo.Rate)
+                                            {
+                                                timerUpdated = true;
+                                                newTimerInfo = new TimerInfo(tempOptions.ID, tempOptions.UpdateInMS);
+                                                break;
+                                            }
+                                            else if (tempOptions.UpdateInMS < newTimerInfo.Rate)
+                                            {
+                                                newTimerInfo = new TimerInfo(tempOptions.ID, tempOptions.UpdateInMS);
+                                            }
+                                        }
+                                    }
+                                    if (timerUpdated == true)
+                                    {
+                                        break;
+                                    }
+                                }
+                                //if the new rate is different then update the thread with new info
+                                if (newTimerInfo.Rate != pidUpdateTimerInfo.Rate)
+                                {
+                                    pidUpdateTimerInfo = newTimerInfo;
+                                    pidUpdateTimer.Change(5, pidUpdateTimerInfo.Rate);
+                                }
+                            }
+                        }
+
+                        //Only one timer just remove it and disable thread
+                        if (this.CounterOptions.Count() == 0)
+                        {
+                            this.UpdateTimer.Dispose();
+                            this.UpdateTimer = null;
+                            this.UpdateTimerInfo = new TimerInfo("", int.MaxValue);
+                        }
+                        else if (this.UpdateTimerInfo.ID == options.ID)
+                        {
+                            bool timerUpdated = false;
+                            TimerInfo newTimerInfo = new TimerInfo("", int.MaxValue);
+                            foreach (var tempCategory in this.CounterOptions.Values)
+                            {
+                                foreach (var tempOptions in tempCategory.Values)
+                                {
+                                    if (tempOptions.ID != options.ID)
+                                    {
+                                        if (tempOptions.UpdateInMS == this.UpdateTimerInfo.Rate)
+                                        {
+                                            timerUpdated = true;
+                                            newTimerInfo = new TimerInfo(tempOptions.ID, tempOptions.UpdateInMS);
+                                            break;
+                                        }
+                                        else if (tempOptions.UpdateInMS < newTimerInfo.Rate)
+                                        {
+                                            newTimerInfo = new TimerInfo(tempOptions.ID, tempOptions.UpdateInMS);
+                                        }
+                                    }
+                                }
+                                if (timerUpdated == true)
+                                {
+                                    break;
+                                }
+                            }
+                            this.UpdateTimerInfo = newTimerInfo;
+                            this.UpdateTimer.Change(5, this.UpdateTimerInfo.Rate);
+                        }
+                    }
+                }
+            }
+
+            //Get an instance of a counter ordered by value
+            public Instance GetInstance(MeasureOptions options, int instanceNumber)
+            {
+                lock (dataLock)
+                {
+                    if (CountersInfo.TryGetValue(options.Counter, out CounterInfo counterInfo))
+                    {
+                        if (instanceNumber == 0 && counterInfo.Sum.TryGetValue(options.BlockString, out double value))
+                        {
+                            return new Instance("Total", value, new CounterSample());
+                        }
+                        //Instances in Rainmeter are not going to be 0 indexed so adjust them to be 0 indexed now
+                        instanceNumber--;
+                        if (counterInfo.ByUsage.TryGetValue(options.BlockString, out List<Instance> tempByUsage))
+                        {
+                            if (tempByUsage.Count() > instanceNumber)
+                            {
+                                return tempByUsage[instanceNumber];
+                            }
+                        }
+                    }
+                }
+                return new Instance("", 0, new CounterSample());
+            }
+            //Get an instance of a counter by name
+            public Instance GetInstance(MeasureOptions options, String instanceName)
+            {
+                lock (dataLock)
+                {
+                    if (CountersInfo.TryGetValue(options.Counter, out CounterInfo counterInfo))
+                    {
+                        if (counterInfo.ByName.TryGetValue(options.IsRollup, out Dictionary<String, Instance> tempByName))
+                        {
+                            if (tempByName.TryGetValue(instanceName, out Instance value))
+                            {
+                                return value;
+                            }
+                        }
+                    }
+                }
+                return new Instance(instanceName, 0, new CounterSample());
+            }
+            public int Count()
+            {
+                return this.CounterOptions.Count();
+            }
+        }
+
+        //This is a list of all the PIDs and their associated process name, used to decode pids to process names
+        private static Dictionary<int, String> pids = new Dictionary<int, String>();
+        //List of all measures that need PIDs decoded
+        private static Dictionary<String, int> pidIDs = new Dictionary<String, int>();
+        //Used to update pids, is set to lowest update rate of a instance that needs it
+        //@TODO share resources with update timers using process category
+        private static Timer pidUpdateTimer;
+        private static TimerInfo pidUpdateTimerInfo = new TimerInfo("", int.MaxValue);
+        private static Object pidUpdateLock = new Object();
+        //This handles keeping the PID list up to date
+        private static void UpdatePIDs()
+        {
+            if (Monitor.TryEnter(pidUpdateLock))
+            {
+                try
+                {
+                    var pidInstance = new PerformanceCounterCategory("Process").ReadCategory()["ID Process"];
+                    var tempPIDs = new Dictionary<int, String>(pidInstance.Count);
+
+                    foreach (InstanceData pid in pidInstance.Values)
+                    {
+                        try
+                        {
+                            //Both Idle and _Total share a PID, ignore them
+                            if (pid.RawValue != 0)
+                            {
+                                tempPIDs.Add((int)pid.RawValue, pid.InstanceName);
+                            }
+                        }
+                        catch
+                        {
+                            //PIDs should be unique but if they somehow are not log an error
+                            API.Log((int)API.LogType.Debug, "UsageMonitor had a process ID collision on PID " + pid);
+                        }
+                    }
+                    pids = tempPIDs;
+                }
+                finally
+                {
+                    Monitor.Exit(pidUpdateLock);
+                }
+            }
+        }
+        
+        //Parses a new MeasureOption set and creates/adds it to a catefory and its collection of counters it is being used for
+        public static void AddMeasure(MeasureOptions options)
+        {
+            if (options.Category != null && options.Counter != null)
+            {
+                //If it already exists just add the ID and update rate to the list
+                if (CategoriesCounters.TryGetValue(options.Category, out Counters counters))
+                {
+                    counters.AddCounter(options);
+                }
+                //If instance does not yet exist it will need to be created
+                else
+                {
+                    counters = new Counters(options);
+                    CategoriesCounters.Add(options.Category, counters);
+                }
+            }
+        }
+        //Removes MeasureOption set and destroys the category if it is the last option using it
+        public static void RemoveMeasure(MeasureOptions options)
+        {
+            if (options.Category != null && options.Counter != null)
+            {
+                //If instance exists remove ID from it
+                if (CategoriesCounters.TryGetValue(options.Category, out Counters counters))
+                {
+                    counters.RemoveCounter(options);
+                    //If nothing is referencing that instance anymore remove and deallocate it
+                    if (counters.Count() == 0)
+                    {
+                        CategoriesCounters.Remove(options.Category);
+                    }
+                }
+            }
+        }
+        //Get an instance of a counter ordered by value
+        public static Instance GetInstance(MeasureOptions options, int instanceNumber)
+        {
+            if (CategoriesCounters.TryGetValue(options.Category, out Counters instanceLists))
+            {
+                return instanceLists.GetInstance(options, instanceNumber);
+            }
+            return new Instance("", 0, new CounterSample());
+        }
+        //Get an instance of a counter by name
+        public static Instance GetInstance(MeasureOptions options, String instanceName)
+        {
+            if (CategoriesCounters.TryGetValue(options.Category, out Counters instanceLists))
+            {
+                return instanceLists.GetInstance(options, instanceName);
+            }
+            return new Instance(instanceName, 0, new CounterSample());
+        }
+    }
+
+    class Measure
+    {
+        static public implicit operator Measure(IntPtr data)
+        {
+            return (Measure)GCHandle.FromIntPtr(data).Target;
+        }
+        public Rainmeter.API API;
+        public MeasureOptions Options;
+    }
+
+    public class Plugin
+    {
+        static Dictionary<string, string> engToCurrLanguage;
+
+        [DllExport]
+        public static void Initialize(ref IntPtr data, IntPtr rm)
+        {
+            data = GCHandle.ToIntPtr(GCHandle.Alloc(new Measure()));
+            ((Measure)data).API = (Rainmeter.API)rm;
+
+            //Check system language, if it is different from en-US build translation list
+            var ci = System.Globalization.CultureInfo.InstalledUICulture.Name;
+            if (ci.CompareTo("en-US") != 0 && engToCurrLanguage == null)
+            {
+                //English list
+                //HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Perflib\009\Counter
+                //Current
+                //HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Perflib\CurrentLanguage\Counter
+                string[] eng = (string[])Microsoft.Win32.Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Perflib\\009", "Counter", "");
+                string[] cur = (string[])Microsoft.Win32.Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Perflib\\CurrentLanguage", "Counter", "");
+                engToCurrLanguage = new Dictionary<string, string>(cur.Length / 2);
+
+                int i = 0;
+                bool isMatch = false;
+                foreach(string item in cur)
+                {
+                    if (i < eng.Length)
+                    {
+                        //If the current item is an ID
+                        if (int.TryParse(item, out int num))
+                        {
+                            if (int.TryParse(eng[i], out int engNum))
+                            {
+                                if (engNum == num)
+                                {
+                                    isMatch = true;
+                                }
+                                else if(engNum < num)
+                                {
+                                    while(engNum < num && i < eng.Length-1)
+                                    {
+                                        i++;
+                                        int.TryParse(eng[i], out engNum);
+                                    }
+                                    if (engNum == num)
+                                    {
+                                        isMatch = true;
+                                    }
+                                }
+                            }
+                        }
+                        else if (isMatch)
+                        {
+                            try
+                            {
+                                engToCurrLanguage.Add(eng[i], item);
+                                isMatch = false;
+                            }
+                            catch
+                            {
+
+                            }
+                        }
+                    }
+                    i++;
+                }
+            }
+        }
+
+        [DllExport]
+        public static void Finalize(IntPtr data)
+        {
+            Measure measure = (Measure)data;
+
+            Categories.RemoveMeasure(measure.Options);
+
+            GCHandle.FromIntPtr(data).Free();
+        }
+
+        [DllExport]
+        public static void Reload(IntPtr data, IntPtr rm, ref double maxValue)
+        {
+            Measure measure = (Measure)data;
+            //We will set this to be the options of the measure later
+            MeasureOptions options = new MeasureOptions(measure.API);
+            measure.API = (Rainmeter.API)rm;
+
+            String aliasString = measure.API.ReadString("Alias", "");
+            MeasureAlias alias = MeasureAlias.CUSTOM;
+            try
+            {
+                if (aliasString.Length > 0)
+                {
+                    alias = (MeasureAlias)Enum.Parse(typeof(MeasureAlias), aliasString, true);
+                }
+            }
+            catch
+            {
+                measure.API.Log(API.LogType.Error, "Alias=" + aliasString + " was not a recognized Alias");
+                alias = MeasureAlias.CPU;
+            }
+            options.DeAlias(alias);
+
+            //Read what Performance Monitor info that we will be sampling
+            String categoryString = measure.API.ReadString("Category", "");
+            if (categoryString.Length > 0)
+            {
+                options.Category = categoryString;
+            }
+            String counterString = measure.API.ReadString("Counter", "");
+            if (counterString.Length > 0)
+            {
+                options.Counter = counterString;
+            }
+
+            //If there is a translation dictionary use it
+            if (engToCurrLanguage != null)
+            {
+                if (engToCurrLanguage.TryGetValue(options.Category, out string translatedString))
+                {
+                    options.UntranslatedCategory = options.Category;
+                    options.Category = translatedString;
+                }
+                //If there is a translation dictionary use it
+                if (engToCurrLanguage.TryGetValue(options.Counter, out translatedString))
+                {
+                    options.UntranslatedCounter = options.Counter;
+                    options.Counter = translatedString;
+                }
+            }
+
+            //All the different options that change the way the info is measured/displayed
+            //Rollup is on by default
+            options.IsRawValue = measure.API.ReadInt("RawValue", Convert.ToInt32(options.IsRawValue)) != 0;
+            options.IsRollup = measure.API.ReadInt("Rollup", Convert.ToInt32(options.IsRollup)) != 0;
+            String whitelist = measure.API.ReadString("Whitelist", "");
+            if (whitelist.Length > 0)
+            {
+                options.UpdateBlockList(BlockType.W, whitelist);
+            }
+            else
+            {
+                String blacklist = measure.API.ReadString("Blacklist", "_Total,Idle");
+                if (blacklist.Length > 0)
+                {
+                    options.UpdateBlockList(BlockType.B, blacklist);
+                }
+                else
+                {
+                    options.UpdateBlockList(BlockType.N, "");
+                }
+            }
+            //Is precent is on by default when measure type is CPU
+            options.IsPercent = measure.API.ReadInt("Percent", Convert.ToInt32(options.IsPercent)) != 0;
+            if (options.IsPercent)
+            {
+                maxValue = 100;
+            }
+            //Is pid is on by default when measure type is GPU or VRAM
+            options.IsPID = measure.API.ReadInt("PIDToName", Convert.ToInt32(options.IsPID)) != 0;
+            //options.UpdateInMS = measure.API.ReadInt("PollRate", options.UpdateInMS);
+            //ID of this options set
+            options.ID = measure.API.GetSkin() + measure.API.GetMeasureName();
+            
+            //This is to prevent !SetOption/DynamicVariables=1 from causing us to keep outdated threads or info
+            //If we have existing options then this measure existed before and needs to be updated
+            if (measure.Options != null && measure.Options.Counter?.Length > 0 && measure.Options.Category?.Length > 0)
+            {
+                if (measure.Options.Category.CompareTo(options.Category) != 0)
+                {
+                    Categories.RemoveMeasure(measure.Options);
+                }
+            }
+
+            //Setup new instance if counter and category are set
+            if (options.Counter?.Length > 0 && options.Category?.Length > 0) Categories.AddMeasure(options);
+
+            //One of these will be used later to access data
+            options.Index = measure.API.ReadInt("Index", 0);
+            options.Name = measure.API.ReadString("Name", null);
+
+            //Now that we are all done we can update the measures options
+            measure.Options = options;
+        }
+
+        [DllExport]
+        public static double Update(IntPtr data)
+        {
+            Measure measure = (Measure)data;
+            MeasureOptions options = measure.Options;
+            double ret = 0;
+            if (options.Counter?.Length > 0 && options.Category?.Length > 0)
+            {
+                if (options.Name.Length > 0)
+                {
+                    //Return raw value if the option is set (RawValue is the value before it goes through CounterSample.Calculate to become human readable)
+                    if (options.IsRawValue)
+                    {
+                        ret = Categories.GetInstance(options, options.Name).Sample.RawValue;
+                    }
+                    else
+                    {
+                        ret = Categories.GetInstance(options, options.Name).Value;
+                    }
+                }
+                else if (options.Index >= 0)
+                {
+                    if (options.IsRawValue)
+                    {
+                        ret = Categories.GetInstance(options, options.Index).Sample.RawValue;
+                    }
+                    else
+                    {
+                        ret = Categories.GetInstance(options, options.Index).Value;
+                    }
+                }
+                else if(options.Index == -1)
+                {
+                    ret = 1337;
+                }
+                //Scale it to be out of 100% if user requests it
+                //@TODO have an option to make this _Sum based?
+                if (options.IsPercent)
+                {
+                    double sum = Categories.GetInstance(options, "_Total").Value;
+
+                    //ret is 0 if it would be NaN
+                    ret = sum > 0 ? ret / sum * 100 : 0;
+                }
+            }
+
+            return ret;
+        }
+
+        [DllExport]
+        public static IntPtr GetString(IntPtr data)
+        {
+            Measure measure = (Measure)data;
+            MeasureOptions options = measure.Options;
+
+            if (options.Counter?.Length > 0 && options.Category?.Length > 0)
+            {
+                if (options.Name.Length > 0)
+                {
+                    return Marshal.StringToHGlobalUni(Categories.GetInstance(options, options.Name).Name);
+                }
+                else if (options.Index >= 0)
+                {
+                    var temp = Categories.GetInstance(options, options.Index);
+                    //If temp.Value is 0 return empty string
+                    if (temp.Value == 0)
+                    {
+                        return Marshal.StringToHGlobalUni("");
+                    }
+                    return Marshal.StringToHGlobalUni(temp.Name);
+                }
+                else if (options.Index == -1)
+                {
+                    return Marshal.StringToHGlobalUni("tjhrulz loves you man");
+                }
+            }
+
+            return IntPtr.Zero;
+        }
+
+        //[DllExport]
+        //public static void ExecuteBang(IntPtr data, [MarshalAs(UnmanagedType.LPWStr)]String args)
+        //{
+        //    Measure measure = (Measure)data;
+        //}
+
+        //[DllExport]
+        //public static IntPtr (IntPtr data, int argc,
+        //    [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 1)] String[] argv)
+        //{
+        //    Measure measure = (Measure)data;
+        //
+        //    return Marshal.StringToHGlobalUni(""); //returning IntPtr.Zero will result in it not being used
+        //}
+    }
+}

--- a/Rainmeter.sln
+++ b/Rainmeter.sln
@@ -69,6 +69,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PluginSpeedFan", "Plugins\P
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PluginSysInfo", "Plugins\PluginSysInfo\PluginSysInfo.vcxproj", "{6EBCA4DA-8CC7-42FE-8F45-878ABE165078}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PluginUsageMonitor", "Plugins\PluginUsageMonitor\PluginUsageMonitor.csproj", "{8B710F76-69EA-4803-9F0A-9DAABE563CF1}"
+	ProjectSection(ProjectDependencies) = postProject
+		{49D56CA5-54AB-45C9-A245-EAE588FCBFE1} = {49D56CA5-54AB-45C9-A245-EAE588FCBFE1}
+	EndProjectSection
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PluginWifiStatus", "Plugins\PluginWifiStatus\PluginWifiStatus.vcxproj", "{45A34285-56DD-4521-912B-3F884D36FA35}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PluginWin7Audio", "Plugins\PluginWin7Audio\PluginWin7Audio.vcxproj", "{6D032D6B-7656-4743-B454-3388E2921EB0}"
@@ -331,8 +336,19 @@ Global
 		{B9184DBA-C6B7-44FE-8BBD-0852DB22D2E4}.Release|Win32.Build.0 = Release|Win32
 		{B9184DBA-C6B7-44FE-8BBD-0852DB22D2E4}.Release|x64.ActiveCfg = Release|x64
 		{B9184DBA-C6B7-44FE-8BBD-0852DB22D2E4}.Release|x64.Build.0 = Release|x64
+		{8B710F76-69EA-4803-9F0A-9DAABE563CF1}.Debug|Win32.ActiveCfg = Debug|x86
+		{8B710F76-69EA-4803-9F0A-9DAABE563CF1}.Debug|Win32.Build.0 = Debug|x86
+		{8B710F76-69EA-4803-9F0A-9DAABE563CF1}.Debug|x64.ActiveCfg = Debug|x64
+		{8B710F76-69EA-4803-9F0A-9DAABE563CF1}.Debug|x64.Build.0 = Debug|x64
+		{8B710F76-69EA-4803-9F0A-9DAABE563CF1}.Release|Win32.ActiveCfg = Release|x86
+		{8B710F76-69EA-4803-9F0A-9DAABE563CF1}.Release|Win32.Build.0 = Release|x86
+		{8B710F76-69EA-4803-9F0A-9DAABE563CF1}.Release|x64.ActiveCfg = Release|x64
+		{8B710F76-69EA-4803-9F0A-9DAABE563CF1}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1638D66B-1685-4AEB-A57B-B5877B2899F1}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
As discussed this is a scalable, multithreaded approach to reading info from Performance Monitor that should be much less resource hungry than the current options. It also does not exhibit the stuttering that the other choices have due to its multithreaded nature.

There are some features I would still like to add like regex blocklists, support for section variables, and one performance tweak that can happen but those can happen in a future version of the plugin.