### PR TITLE
Usage monitor bugfixes

### DIFF
--- a/Plugins/PluginUsageMonitor/UsageMonitor.cs
+++ b/Plugins/PluginUsageMonitor/UsageMonitor.cs
@@ -880,7 +880,7 @@ namespace UsageMonitor
             }
             public Instance GetAverage(MeasureOptions options)
             {
-                Instance instance = new Instance("Total", 0, new CounterSample());
+                Instance instance = new Instance("Average", 0, new CounterSample());
                 lock (dataLock)
                 {
                     if (CountersInfo.TryGetValue(options.Counter, out CounterInfo counterInfo))

--- a/Plugins/PluginUsageMonitor/UsageMonitor.cs
+++ b/Plugins/PluginUsageMonitor/UsageMonitor.cs
@@ -1304,6 +1304,11 @@ namespace UsageMonitor
                         {
                             ret = ret / options.currInstace._Total.Value * 100;
                         }
+                        //If ret is bigger than 100 (Normally caused by double vs float differences since this plugin is more accurate than permon _Total is) cap it
+                        if(ret > 100)
+                        {
+                            ret = 100;
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
Adds Index=-1 to reference Average instead of a hidden easter egg. This is intended for counters where _Total references the average of all instances and not the sum.
Fixes disabled and paused measures strings still updating. Also disabled measures will not continue to check PerfMon.exe for updated values now (Paused still will so the measure is up to date the moment you unpause it ) so there will be no CPU usage when disabled.
Fixed some issues where the measure would have a small chance of referencing two different updates of PerfMon.exe so Percent=1 would be the wrong value (Only noticeable to a user when it would case the percent to exceed 100) or the string value would be for a new update cycle and the number value would be for the last update cycle.
When the measure has Percent=1 the number value now can not exceed 100 to prevent floating point imprecision errors causing it to look like some number just above 100 such as 100.0000527