### PR TITLE
Adds InterpolationMode option to Image meter. This option changes the…

### DIFF
--- a/Library/MeterImage.h
+++ b/Library/MeterImage.h
@@ -52,10 +52,13 @@ private:
 
 	bool m_NeedsRedraw;
 	DRAWMODE m_DrawMode;
+	Gdiplus::InterpolationMode m_InterpolationMode;
 
 	RECT m_ScaleMargins;
 
 	static const WCHAR* c_MaskOptionArray[TintedImage::OptionCount];
+
+	void ReadInterpolationMode(const WCHAR* interpolationMode);
 };
 
 #endif


### PR DESCRIPTION
… interpolation mode used for scaling.

My personal use case for this is sharper scaling when using ScaleMargins:
Before: 
![image](https://user-images.githubusercontent.com/4542944/40881308-5ce421f2-66c3-11e8-9c9e-2a9d5e96b3d6.png)
After with HighQualityBilinear interpolation mode:
![image](https://user-images.githubusercontent.com/4542944/40881310-6dd7b5b4-66c3-11e8-81ce-a4005349254d.png)

This might be useful for other users as well, hence this PR.
Please let me know if any changes are needed.