### PR TITLE
Fix potential hanging as a multithreaded app (ActionTimer)

### DIFF
--- a/Library/MeasurePlugin.cpp
+++ b/Library/MeasurePlugin.cpp
@@ -16,11 +16,11 @@ MeasurePlugin::MeasurePlugin(Skin* skin, const WCHAR* name) : Measure(skin, name
 	m_ReloadFunc(),
 	m_ID(),
 	m_Update2(false),
-	m_MultiThreaded(false),
 	m_PluginData(),
 	m_UpdateFunc(),
 	m_GetStringFunc(),
-	m_ExecuteBangFunc()
+	m_ExecuteBangFunc(),
+	m_OverrideDirectoryFunc()
 {
 }
 
@@ -70,7 +70,7 @@ void MeasurePlugin::UpdateValue()
 		}
 
 		// Reset to default
-		if (!m_MultiThreaded)
+		if (!m_OverrideDirectoryFunc)
 		{
 			System::ResetWorkingDirectory();
 		}
@@ -110,11 +110,6 @@ void MeasurePlugin::ReadOptions(ConfigParser& parser, const WCHAR* section)
 		pluginName = plugin;
 	}
 
-	if (_wcsnicmp(pluginName.c_str(), L"ACTIONTIMER", 11) == 0)
-	{
-		m_MultiThreaded = true;
-	}
-
 	// First try from program path
 	std::wstring pluginFile = GetRainmeter().GetPluginPath();
 	pluginFile += pluginName;
@@ -142,6 +137,7 @@ void MeasurePlugin::ReadOptions(ConfigParser& parser, const WCHAR* section)
 	m_UpdateFunc = GetProcAddress(m_Plugin, "Update");
 	m_GetStringFunc = GetProcAddress(m_Plugin, "GetString");
 	m_ExecuteBangFunc = GetProcAddress(m_Plugin, "ExecuteBang");
+	m_OverrideDirectoryFunc = GetProcAddress(m_Plugin, "OverrideDirectory");
 
 	// Remove current directory from DLL search path
 	SetDllDirectory(L"");
@@ -193,7 +189,7 @@ void MeasurePlugin::ReadOptions(ConfigParser& parser, const WCHAR* section)
 
 	// Reset to default
 	SetDllDirectory(L"");
-	if (!m_MultiThreaded)
+	if (!m_OverrideDirectoryFunc)
 	{
 		System::ResetWorkingDirectory();
 	}
@@ -276,6 +272,7 @@ bool MeasurePlugin::CommandWithReturn(const std::wstring& command, std::wstring&
 			function == "Update" ||
 			function == "GetString" ||
 			function == "ExecuteBang" ||
+			function == "OverrideDirectory" ||
 			function == "Finalize" ||
 			function == "Update2" ||				// Old API
 			function == "GetPluginAuthor" ||		// Old API

--- a/Library/MeasurePlugin.cpp
+++ b/Library/MeasurePlugin.cpp
@@ -16,6 +16,7 @@ MeasurePlugin::MeasurePlugin(Skin* skin, const WCHAR* name) : Measure(skin, name
 	m_ReloadFunc(),
 	m_ID(),
 	m_Update2(false),
+	m_MultiThreaded(false),
 	m_PluginData(),
 	m_UpdateFunc(),
 	m_GetStringFunc(),
@@ -69,7 +70,10 @@ void MeasurePlugin::UpdateValue()
 		}
 
 		// Reset to default
-		System::ResetWorkingDirectory();
+		if (!m_MultiThreaded)
+		{
+			System::ResetWorkingDirectory();
+		}
 	}
 }
 
@@ -104,6 +108,11 @@ void MeasurePlugin::ReadOptions(ConfigParser& parser, const WCHAR* section)
 	else
 	{
 		pluginName = plugin;
+	}
+
+	if (_wcsnicmp(pluginName.c_str(), L"ACTIONTIMER", 11) == 0)
+	{
+		m_MultiThreaded = true;
 	}
 
 	// First try from program path
@@ -184,7 +193,10 @@ void MeasurePlugin::ReadOptions(ConfigParser& parser, const WCHAR* section)
 
 	// Reset to default
 	SetDllDirectory(L"");
-	System::ResetWorkingDirectory();
+	if (!m_MultiThreaded)
+	{
+		System::ResetWorkingDirectory();
+	}
 
 	++id;
 }

--- a/Library/MeasurePlugin.h
+++ b/Library/MeasurePlugin.h
@@ -60,6 +60,7 @@ private:
 		{
 			UINT m_ID;
 			bool m_Update2;
+			bool m_MultiThreaded;
 		};
 
 		struct

--- a/Library/MeasurePlugin.h
+++ b/Library/MeasurePlugin.h
@@ -60,7 +60,6 @@ private:
 		{
 			UINT m_ID;
 			bool m_Update2;
-			bool m_MultiThreaded;
 		};
 
 		struct
@@ -72,6 +71,7 @@ private:
 	void* m_UpdateFunc;
 	void* m_GetStringFunc;
 	void* m_ExecuteBangFunc;
+	void* m_OverrideDirectoryFunc;
 };
 
 #endif


### PR DESCRIPTION
MeasurePlugin::UpdateValue() -> [System::ResetWorkingDirectory()](https://github.com/rainmeter/rainmeter/blob/47c9986fdd5f77078141e9c78c999fad79480042/Library/System.cpp#L1069-L1077) -> GetCurrentDirectory() / SetCurrentDirectory()

From [MSDN](https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-getcurrentdirectory):

"Multithreaded applications and shared library code should not use the
GetCurrentDirectory function and should avoid using relative path names. The current directory state written by the SetCurrentDirectory function is stored as a global variable in each process, therefore multithreaded applications cannot reliably use this value without possible data corruption from other threads that may also be reading or setting this value. This limitation also applies to the SetCurrentDirectory and GetFullPathName functions. The exception being when the application is guaranteed to be running in a single thread, for example parsing file names from the command line argument string in the main thread prior to creating any additional threads. Using relative path names in multithreaded applications or shared library code can yield unpredictable results and is not supported."