### PR TITLE
Allow images, that are open for writing, be loaded.

### DIFF
--- a/Common/Gfx/Util/D2DBitmapLoader.cpp
+++ b/Common/Gfx/Util/D2DBitmapLoader.cpp
@@ -22,7 +22,7 @@ HRESULT D2DBitmapLoader::LoadBitmapFromFile(const Canvas& canvas, D2DBitmap* bit
 
 	HANDLE fileHandle = CreateFile(
 		path.c_str(),
-		GENERIC_READ, FILE_SHARE_READ,
+		GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
 		nullptr,
 		OPEN_EXISTING,
 		FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,
@@ -127,7 +127,7 @@ bool D2DBitmapLoader::HasFileChanged(D2DBitmap* bitmap, const std::wstring& file
 
 	HANDLE fileHandle = CreateFile(
 		file.c_str(),
-		GENERIC_READ, FILE_SHARE_READ,
+		GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
 		nullptr,
 		OPEN_EXISTING,
 		FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,
@@ -154,7 +154,7 @@ HRESULT D2DBitmapLoader::GetFileInfo(const std::wstring& path, FileInfo* fileInf
 
 	HANDLE fileHandle = CreateFile(
 		path.c_str(),
-		GENERIC_READ, FILE_SHARE_READ,
+		GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
 		nullptr,
 		OPEN_EXISTING,
 		FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,


### PR DESCRIPTION
This is primarily allowing plugins to create images without need to write anything to disk.

Construction like this
`CreateFileW(path, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_DELETE, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_TEMPORARY, nullptr);`
allows you to have a file in memory. But only until the handle is open.

r3266 can't open such files because it doesn't specify FILE_SHARE_WRITE mode, and handle with write access can't be closed as this will cause flush file data to disk.
This commit fixes this.