### PR TITLE
Fixed autoscaling for Line and Histogram meters and added additional autoscaling functionality

### DIFF
--- a/Library/MeterHistogram.h
+++ b/Library/MeterHistogram.h
@@ -27,6 +27,16 @@ public:
 	virtual bool Draw(Gfx::Canvas& canvas);
 
 protected:
+
+	enum AUTOSCALE_TYPE
+	{
+		NONE = 0,
+		INDEPENDENT,
+		PRIMARY,
+		SECONDARY,
+		MAXIMUM
+	};
+
 	virtual void ReadOptions(ConfigParser& parser, const WCHAR* section);
 	virtual void BindMeasures(ConfigParser& parser, const WCHAR* section);
 
@@ -41,7 +51,8 @@ private:
 	D2D1_COLOR_F m_OverlapColor;
 
 	int m_MeterPos;							// New value placement position
-	bool m_Autoscale;
+	bool m_AutoScale;
+	AUTOSCALE_TYPE m_AutoScaleType;
 	bool m_Flip;
 
 	std::wstring m_PrimaryImageName;
@@ -61,7 +72,7 @@ private:
 	double m_MinSecondaryValue;
 
 	bool m_SizeChanged;
-	
+
 	bool m_GraphStartLeft;
 	bool m_GraphHorizontalOrientation;
 

--- a/Library/MeterLine.h
+++ b/Library/MeterLine.h
@@ -33,7 +33,8 @@ private:
 	std::vector<D2D1_COLOR_F> m_Colors;
 	std::vector<double> m_ScaleValues;
 
-	bool m_Autoscale;
+	bool m_AutoScale;
+	int m_AutoScaleMeasure;
 	bool m_HorizontalLines;
 	bool m_Flip;
 	double m_LineWidth;


### PR DESCRIPTION
The MinValue and MaxValue for both meters now linearly scales between the two.

AutoScale for the Line meter can be now be dependent on a measure by using AutoScaleMeasure=#index#. AutoScale=1 is not needed if an AutoScaleMeasure index is supplied but nonetheless it still has its full functionality.

AutoScale for a Histogram meter using two measures can now scale each measure independantly, on primary, on secondary or on the maximum of the two (primary and secondary somewhat redundant most of the time). The setting is AutoScaleType and valid inputs are: "Independent", "Primary", "Secondary", "Maximum". The AutoScale option still works similarly as in the Line meter case and defaults to independent autoscaling. AutoScaleType can be ommited when AutoScale=1 is used.