### PR TITLE
Fix a bug with the !EnableMeasure bang that silently fails if Dynamic…

### DIFF
--- a/Library/Skin.cpp
+++ b/Library/Skin.cpp
@@ -1490,7 +1490,10 @@ void Skin::EnableMeasure(const std::wstring& name, bool group)
 	{
 		if (CompareName((*i), measure, group))
 		{
+			// The Enable() call will fail unless DynamicVariables are forced on
+			(*i)->SetDynamicVariables(true);
 			(*i)->Enable();
+
 			if (!group) return;
 		}
 	}


### PR DESCRIPTION
…Variables are turned off

This is a bug I found when trying to troubleshoot why the `!EnableMeasure` bang was not working consistently when called from a WebParser measure's `FinishAction`.  Please review for inclusion into master.