### PR TITLE
Update PlayerWinamp.cpp

### DIFF
--- a/Library/NowPlaying/PlayerWinamp.cpp
+++ b/Library/NowPlaying/PlayerWinamp.cpp
@@ -25,8 +25,7 @@ PlayerWinamp::PlayerWinamp(WINAMPTYPE type) : Player(),
 	m_UseUnicodeAPI(false),
 	m_PlayingStream(false),
 	m_WinampType(type),
-	m_WinampHandle(),
-	m_WinampAddress()
+	m_WinampHandle()
 {
 }
 
@@ -70,14 +69,13 @@ bool PlayerWinamp::CheckWindow()
 		m_Window = FindWindow(L"Winamp v1.x", nullptr);
 		if (m_Window)
 		{
-			DWORD pID;
+			DWORD pID = 0;
 			GetWindowThreadProcessId(m_Window, &pID);
 			m_WinampHandle = OpenProcess(PROCESS_VM_READ, FALSE, pID);
 
 			if (m_WinampHandle)
 			{
-				m_WinampAddress = (LPCVOID)SendMessage(m_Window, WM_WA_IPC, 0, IPC_GET_PLAYING_FILENAME);
-				m_UseUnicodeAPI = m_WinampAddress ? true : false;
+				m_UseUnicodeAPI = (LPCVOID)SendMessage(m_Window, WM_WA_IPC, 0, IPC_GET_PLAYING_FILENAME) ? true : false;
 				m_Initialized = true;
 			}
 		}
@@ -125,7 +123,8 @@ void PlayerWinamp::UpdateData()
 
 		if (m_UseUnicodeAPI)
 		{
-			if (!ReadProcessMemory(m_WinampHandle, m_WinampAddress, &wBuffer, sizeof(wBuffer), nullptr))
+			LPCVOID address = (LPCVOID)SendMessage(m_Window, WM_WA_IPC, 0, IPC_GET_PLAYING_FILENAME);
+			if (!ReadProcessMemory(m_WinampHandle, address, &wBuffer, sizeof(wBuffer), nullptr))
 			{
 				// Failed to read memory
 				return;
@@ -237,7 +236,7 @@ void PlayerWinamp::UpdateData()
 					}
 
 					if (!CCover::GetLocal(L"cover", trackFolder, m_CoverPath) &&
-						!CCover::GetLocal(L"folder", trackFolder, m_CoverPath))
+					    !CCover::GetLocal(L"folder", trackFolder, m_CoverPath))
 					{
 						// Nothing found
 						m_CoverPath.clear();


### PR DESCRIPTION
The return buffer of IPC_GET_PLAYING_FILENAME & other Winamp api that return a string aren't guaranteed to always be at the same memory location in the running instance.

This change accounts for that plus it also makes things work better with WACUP (an effort to make a Winamp 5.666 compatible replacement) which would only show the first item played with how the existing code worked.