### PR TITLE
Fix: Range-check volume value for CAD plugin

### DIFF
--- a/Library/NowPlaying/PlayerCAD.cpp
+++ b/Library/NowPlaying/PlayerCAD.cpp
@@ -224,7 +224,13 @@ LRESULT CALLBACK PlayerCAD::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM l
 
 		case IPC_VOLUME_CHANGED_NOTIFICATION:
 			{
-				player->m_Volume = (UINT)wParam;
+				UINT volume = (UINT)wParam;
+				if(volume <= 100)
+				{
+					// Range check the volume, so we don't see buggy values
+					player->m_Volume = volume;
+					break;
+				}
 				break;
 			}
 
@@ -413,7 +419,12 @@ void PlayerCAD::UpdateData()
 	if (m_State != STATE_STOPPED)
 	{
 		m_Position = (UINT)SendMessage(m_PlayerWindow, WM_USER, 0, IPC_GET_POSITION);
-		m_Volume = (UINT)SendMessage(m_PlayerWindow, WM_USER, 0, IPC_GET_VOLUME);
+		UINT volume = (UINT)SendMessage(m_PlayerWindow, WM_USER, 0, IPC_GET_VOLUME);
+		if(volume <= 100)
+		{
+			// Range check the volume, so we don't see buggy values
+			m_Volume = volume;
+		}
 	}
 }
 


### PR DESCRIPTION
The NowPlaying measure expects volume values to be within the range of 0- 100.

However, when recieving a volume value, the CAD plugin fails to range-check it, and just drops it in regardless, which can cause unexpected results.

I noticed this using JRiver Media Center 28 to playback images, where it's CAD interface seems to return uint.MaxValue (as images have no volume) for the volume.
Whilst this is probably a JRiver bug at the end of the day, it seems sensible to range-check the value is what we expect before passing it to the measure, as large values can mess up skins in interesting ways.

