### PR TITLE
Use latest ilasm.exe in DLLExporter

### DIFF
--- a/Build/DllExporter/Program.cs
+++ b/Build/DllExporter/Program.cs
@@ -175,7 +175,7 @@ namespace DllExporter
         {
             var arch = x64 ? DotNetFrameworkArchitecture.Bitness64 : DotNetFrameworkArchitecture.Bitness32;
             var path = ToolLocationHelper.GetPathToDotNetFrameworkFile(
-                "ilasm.exe", TargetDotNetFrameworkVersion.Version20, arch);
+                "ilasm.exe", TargetDotNetFrameworkVersion.VersionLatest, arch);
             return File.Exists(path) ? path : null;
         }
 


### PR DESCRIPTION
Use `TargetDotNetFrameworkVersion.VersionLatest` instead of `TargetDotNetFrameworkVersion.Version20` to find **ilasm.exe**. This fixes assembly errors when using latest .NET Framework libraries in your plugin.