### PR TITLE
Enable Lua Update function to return two-element tables

### DIFF
--- a/Library/MeasureScript.cpp
+++ b/Library/MeasureScript.cpp
@@ -69,7 +69,7 @@ void MeasureScript::UpdateValue()
 */
 const WCHAR* MeasureScript::GetStringValue()
 {
-	return (m_ValueType == LUA_TSTRING) ? CheckSubstitute(m_StringValue.c_str()) : nullptr;
+	return (m_ValueType == LUA_TSTRING || m_ValueType == LUA_TTABLE) ? CheckSubstitute(m_StringValue.c_str()) : nullptr;
 }
 
 /*


### PR DESCRIPTION
This enables the Update function in the script measure to return a two-element table of which the first value will be the number value, and the second, the string value of the measure.

Example:
```lua
function Update()
    return { 24, "TwentyFour" }
end
```

Usage:
```ini
[ResultText]
Meter=String
MeterStyle=GithubCodeBlockStyle
Text="Num = [MeasureScript:] | Str = [MeasureScript]"
```
Result:
```txt
Num = 24 | Str = TwentyFour
```