### PR TITLE
Fix skin draggable checkbox not updating state when global setting is changed

### DIFF
--- a/Library/DialogManage.cpp
+++ b/Library/DialogManage.cpp
@@ -163,6 +163,14 @@ void DialogManage::UpdateSkins(Skin* skin, bool deleted)
 	}
 }
 
+void DialogManage::UpdateSkinDraggableCheckBox()
+{
+	if (c_Dialog && c_Dialog->m_TabSkins.IsInitialized())
+	{
+		c_Dialog->m_TabSkins.UpdateDraggableCheckBox();
+	}
+}
+
 void DialogManage::UpdateLayouts()
 {
 	if (c_Dialog && c_Dialog->m_TabLayouts.IsInitialized())
@@ -769,17 +777,7 @@ void DialogManage::TabSkins::SetControls()
 		item = GetControl(Id_DisplayMonitorButton);
 		EnableWindow(item, TRUE);
 
-		item = GetControl(Id_DraggableCheckBox);
-		if (GetRainmeter().GetDisableDragging())
-		{
-			EnableWindow(item, FALSE);
-			Button_SetCheck(item, BST_UNCHECKED);
-		}
-		else
-		{
-			EnableWindow(item, TRUE);
-			Button_SetCheck(item, m_SkinWindow->GetWindowDraggable());
-		}
+		UpdateDraggableCheckBox();
 
 		item = GetControl(Id_ClickThroughCheckBox);
 		EnableWindow(item, TRUE);
@@ -832,6 +830,24 @@ void DialogManage::TabSkins::SetControls()
 	else
 	{
 		SetWindowText(item, GetString(ID_STR_LOAD));
+	}
+}
+
+void DialogManage::TabSkins::UpdateDraggableCheckBox()
+{
+	if (m_SkinWindow)
+	{
+		HWND item = GetControl(Id_DraggableCheckBox);
+		if (GetRainmeter().GetDisableDragging())
+		{
+			EnableWindow(item, FALSE);
+			Button_SetCheck(item, BST_UNCHECKED);
+		}
+		else
+		{
+			EnableWindow(item, TRUE);
+			Button_SetCheck(item, m_SkinWindow->GetWindowDraggable());
+		}
 	}
 }
 

--- a/Library/DialogManage.h
+++ b/Library/DialogManage.h
@@ -30,6 +30,7 @@ public:
 	static void UpdateSelectedSkinOptions(Skin* skin);
 
 	static void UpdateSkins(Skin* skin, bool deleted = false);
+	static void UpdateSkinDraggableCheckBox();
 	static void UpdateLayouts();
 	static void UpdateGameMode();
 
@@ -90,6 +91,7 @@ private:
 
 		void UpdateSelected(Skin* skin);
 		void Update(Skin* skin, bool deleted);
+		void UpdateDraggableCheckBox();
 
 		static void SelectTreeItem(HWND tree, HTREEITEM item, LPCWSTR name);
 

--- a/Library/Rainmeter.cpp
+++ b/Library/Rainmeter.cpp
@@ -2146,6 +2146,7 @@ void Rainmeter::SetDebug(bool debug)
 void Rainmeter::SetDisableDragging(bool dragging)
 {
 	m_DisableDragging = dragging;
+	DialogManage::UpdateSkinDraggableCheckBox();
 	WritePrivateProfileString(L"Rainmeter", L"DisableDragging", dragging ? L"1" : L"0", m_IniFile.c_str());
 }
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![Rainmeter_730tVPbf5a](https://user-images.githubusercontent.com/35318437/193188487-f9a82e5f-8e77-474c-8f48-512c61a2f301.gif) | ![Rainmeter_EkLYOnj077](https://user-images.githubusercontent.com/35318437/193188694-21276980-a55d-4641-a316-a43edc7e2779.gif) |