### PR TITLE
WebParser: add functionality for JSON parsing

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,17 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [
+                "_DEBUG",
+                "UNICODE",
+                "_UNICODE"
+            ],
+            "compilerPath": "D:/Programme_x86/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.35.32215/bin/Hostx64/x64/cl.exe"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Rainmeter",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "x32-Debug/Rainmeter.exe",
+            "cwd": "${workspaceRoot}",
+            "logging": {
+              "moduleLoad": false,
+              "trace": true
+            },
+          }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build all",
+            "type": "shell",
+            "command": "./build.bat",
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/Library/MeasureWebParser.h
+++ b/Library/MeasureWebParser.h
@@ -48,9 +48,11 @@ protected:
 private:
 	static unsigned __stdcall NetworkThreadProc(void* pParam);
 	static unsigned __stdcall NetworkDownloadThreadProc(void* pParam);
-	void ParseData(const BYTE* rawData, DWORD rawSize, bool utf16Data = false);
+	void ParseData(const WCHAR* data, DWORD dataLength);
 	void ParseDataRegex(const WCHAR *data, DWORD dataLength);
 	void ParseDataJson(const WCHAR *data, DWORD dataLength);
+	bool IsParsingConfigured() const;
+	void ClearResult();
 
 	std::wstring m_Url;
 	ParseMode m_ParseMode;

--- a/Library/MeasureWebParser.h
+++ b/Library/MeasureWebParser.h
@@ -49,8 +49,8 @@ private:
 	static unsigned __stdcall NetworkThreadProc(void* pParam);
 	static unsigned __stdcall NetworkDownloadThreadProc(void* pParam);
 	void ParseData(const WCHAR* data, DWORD dataLength);
-	void ParseDataRegex(const WCHAR *data, DWORD dataLength);
-	void ParseDataJson(const WCHAR *data, DWORD dataLength);
+	bool ParseDataRegex(const WCHAR *data, DWORD dataLength);
+	bool ParseDataJson(const WCHAR *data, DWORD dataLength);
 	bool IsParsingConfigured() const;
 	void ClearResult();
 
@@ -61,7 +61,7 @@ private:
 	std::wstring m_ResultString;
 	std::wstring m_ErrorString;
 	std::wstring m_FinishAction;
-	std::wstring m_OnRegExpErrAction;
+	std::wstring m_OnParseErrAction;
 	std::wstring m_OnConnectErrAction;
 	std::wstring m_OnDownloadErrAction;
 	std::wstring m_DownloadFolder;

--- a/Library/MeasureWebParser.h
+++ b/Library/MeasureWebParser.h
@@ -51,6 +51,7 @@ private:
 	void ParseData(const WCHAR* data, DWORD dataLength);
 	bool ParseDataRegex(const WCHAR *data, DWORD dataLength);
 	bool ParseDataJson(const WCHAR *data, DWORD dataLength);
+	void ProcessMatch(const std::wstring& match, const std::wstring& parentMeasureReference);
 	bool IsParsingConfigured() const;
 	void ClearResult();
 	void StartDownloadThread();

--- a/Library/MeasureWebParser.h
+++ b/Library/MeasureWebParser.h
@@ -53,6 +53,7 @@ private:
 	bool ParseDataJson(const WCHAR *data, DWORD dataLength);
 	bool IsParsingConfigured() const;
 	void ClearResult();
+	void StartDownloadThread();
 
 	std::wstring m_Url;
 	ParseMode m_ParseMode;

--- a/Library/MeasureWebParser.h
+++ b/Library/MeasureWebParser.h
@@ -10,6 +10,8 @@
 
 #include "Measure.h"
 
+#include <vector>
+
 struct ProxySetting
 {
 	std::wstring agent;
@@ -17,6 +19,12 @@ struct ProxySetting
 	HINTERNET handle;
 
 	ProxySetting() : handle() {}
+};
+
+enum class ParseMode
+{
+	Regex,
+	Json
 };
 
 class MeasureWebParser : public Measure
@@ -41,9 +49,13 @@ private:
 	static unsigned __stdcall NetworkThreadProc(void* pParam);
 	static unsigned __stdcall NetworkDownloadThreadProc(void* pParam);
 	void ParseData(const BYTE* rawData, DWORD rawSize, bool utf16Data = false);
+	void ParseDataRegex(const WCHAR *data, DWORD dataLength);
+	void ParseDataJson(const WCHAR *data, DWORD dataLength);
 
 	std::wstring m_Url;
+	ParseMode m_ParseMode;
 	std::wstring m_RegExp;
+	std::vector<std::wstring> m_JsonValueSpecs;
 	std::wstring m_ResultString;
 	std::wstring m_ErrorString;
 	std::wstring m_FinishAction;

--- a/Version.cs
+++ b/Version.cs
@@ -3,9 +3,9 @@ namespace Rainmeter
     public class Version
     {
 #if X64
-        public const string Informational = "0.0.0.0 (64-bit)";
+        public const string Informational = "4.5.17.3700-dev (64-bit)";
 #else
-        public const string Informational = "0.0.0.0 (32-bit)";
+        public const string Informational = "4.5.17.3700-dev (32-bit)";
 #endif
     }
 }

--- a/Version.h
+++ b/Version.h
@@ -1,9 +1,9 @@
 #pragma once
-#define FILEVER 0,0,0,0
+#define FILEVER 4,5,17,37
 #define PRODUCTVER FILEVER
-#define STRFILEVER "0.0.0.0"
+#define STRFILEVER "4.5.17.37"
 #define STRPRODUCTVER STRFILEVER
-#define APPVERSION L"0.0.0"
-#define RAINMETER_VERSION ((0 * 1000000) + (0 * 1000) + 0)
+#define APPVERSION L"4.5.17"
+#define RAINMETER_VERSION ((4 * 1000000) + (5 * 1000) + 17)
 #define STRCOPYRIGHT "0000 Rainmeter Team"
 const int revision_number = 0;

--- a/build-release.bat
+++ b/build-release.bat
@@ -1,0 +1,2 @@
+call "D:\Program Files (x86)\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat"
+msbuild Rainmeter.sln /property:Configuration=Release

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,2 @@
+call "D:\Program Files (x86)\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat"
+msbuild Rainmeter.sln


### PR DESCRIPTION
Hi, this PR adds functionality for JSON parsing to WebParser. Json matches are defined by using "json pointers" as explained below. Let me know if that is a valuable addition and I'll do my best to bring this pull request in shape according to your guidance.

JSON parsing is enabled by specifying
  ParseMode=Json

Once JSON parsing is enabled, the configurations in
JsonValuePath<N> are specifying the JSON pointer expressions
that should be applied to the JSON data. <N> is >= 1.
JSON pointers are explained in
https://github.com/nlohmann/json#json-pointer-and-json-patch

Example:
  [JsonParser]
  Measure=WebParser
  Url=file://#CURRENTPATH#weather-api.json
  ParseMode=Json
  JsonValuePath1=/id/days/1/temperatureMin
  JsonValuePath2=/id/days/2/temperatureMin
  JsonValuePath3=/id/days/3/temperatureMin
  JsonValuePath4=/id/days/4/temperatureMin
  JsonValuePath5=/id/days/4/doesNotExist
  JsonValuePath6=/id/days/1

In this case, the file weather-api.json will be parsed as
a JSON file and the expressions in JsonValuePath1 to
JsonValuePath6 are applied. The matches of these expressions
can be referenced by other measures by the usual StringIndex
mechanic. StringIndex=0 references the whole JSON data, similar
to Regex mode, e.g. this measure will have the whole JSON file
as its value.
JsonValuePath5 in the example above references data that does
not exist, e.g. the evaluation will fail. JSON parsing will
assign the value "N/A" in this case for this expression.

Example for referencing WebParser with JSON parsing:
  [Day2TempMin]
  Measure=WebParser
  Url=[JsonParser]
  StringIndex=2

This measure will get the result of "/id/days/2/temperatureMin".

Regex mode has the ability to reference the output of another
WebParser instance and apply another round of Regex. The same
applies to JSON parse mode.

Example:
  [JsonParserChild]
  Measure=WebParser
  Url=[JsonParser]
  ParseMode=Json
  StringIndex=6
  JsonValuePath1=/temperatureMin
  JsonValuePath2=/temperatureMax
  JsonValuePath3=/precipitation
  StringIndex2=3

This references the Index 6 output of [JsonParser], which is the
match for "/id/days/1". Then expressions JsonValuePath1 -
JsonValuePath3 are applied on that value and JsonValuePath3 is
taken for the value of this measure (as defined by StringIndex2=3).