### PR TITLE
Update illustro Network.ini

### DIFF
--- a/Build/Skins/illustro/Network/Network.ini
+++ b/Build/Skins/illustro/Network/Network.ini
@@ -42,7 +42,7 @@ Measure=Plugin
 Plugin=WebParser
 URL=https://checkip.amazonaws.com/
 UpdateRate=14400
-RegExp=(?siU)^(.*)$
+RegExp=(?s)^(.*)$
 StringIndex=1
 Substitute="":"N/A"
 ; Substitute works as follows: "A":"B" where A is a string to substitute and B is a string


### PR DESCRIPTION
```ini
[measureIP]
Measure=Plugin
Plugin=WebParser
URL=https://checkip.amazonaws.com/
UpdateRate=14400
RegExp=(?siU)^(.*)$
StringIndex=1
Substitute="":"N/A"
```
WebParser `RegExp=(?siU)^(.*)$` option is not a good example to use.

> Testing on [regex101](https://regex101.com)  
> settings FLAVOR `PCRE (PHP <7.3)` Function `Match` REGEX FLAGS `none`
> testing string `192.168.100.254`

&nbsp;|RegExp|Steps
:-|:-|:-:
before|[`(?siU)^(.*)$`](https://regex101.com/r/JZyIGw/1)|37
after|[`(?s)^(.*)$`](https://regex101.com/r/ROyP4J/1)|7

`s` modifier: single line. Dot matches newline characters
`i` modifier: insensitive. Case insensitive match (ignores case of [a-zA-Z])
`U` modifier: Ungreedy. The match becomes lazy by default. Now a ? following a quantifier makes it greedy

If a remote file is XX kilobytes in size, such as JSON or XML, it will make a big difference to parse.
See also Rainmeter forum my [post](https://forum.rainmeter.net/viewtopic.php?t=34628&start=620#p187749)
