### PR TITLE
Fix cursor changing to a hand when a meter has a mouse wheel action

### DIFF
--- a/Library/Mouse.cpp
+++ b/Library/Mouse.cpp
@@ -162,7 +162,7 @@ HCURSOR Mouse::GetCursor(bool isButton) const
 	{
 		// Disabled non-button mouse actions should use the default "arrow" pointer
 		bool getCursor = false;
-		for (size_t i = 0; i < (MOUSEACTION_COUNT - 2); ++i)	// Do not process Over/Leave
+		for (size_t i = 0; i < (MOUSEACTION_COUNT - 6); ++i)	// Do not process mouse wheel and Over/Leave
 		{
 			if (m_MouseActions[i].state == MOUSEACTION_ENABLED &&
 				!m_MouseActions[i].action.empty())


### PR DESCRIPTION
Not sure if intentional:

| Before | After |
| --- | --- |
| ![Rainmeter_enroN1Q62W](https://user-images.githubusercontent.com/35318437/236972141-395703ba-a609-4c94-ae8b-aca961ce0620.gif) | ![Rainmeter_Ght6XvBkIP](https://user-images.githubusercontent.com/35318437/236972073-a85a25e5-616e-48e8-ac09-4f1a7c2b2559.gif) |