### PR TITLE
Fix skin meter `MouseLeaveAction` being delayed when skin is draggable and global dragging is disabled

### DIFF
--- a/Library/Skin.cpp
+++ b/Library/Skin.cpp
@@ -507,7 +507,7 @@ void Skin::SetMouseLeaveEvent(bool cancel)
 
 	// Set the mouse event
 	tme.dwFlags = TME_LEAVE;
-	if (m_WindowDraggable)
+	if (m_WindowDraggable && !GetRainmeter().GetDisableDragging())
 	{
 		tme.dwFlags |= TME_NONCLIENT;
 	}


### PR DESCRIPTION
Here's a simple meter:
```ini
[MeterString]
Meter=String
Text=Unhovered
MouseOverAction=[!SetOption MeterString Text Hovered][!UpdateMeter MeterString][!Redraw]
MouseLeaveAction=[!SetOption MeterString Text Unhovered][!UpdateMeter MeterString][!Redraw]
SolidColor=255,255,255
```

Before:
![hEU02neqe4](https://github.com/rainmeter/rainmeter/assets/35318437/d389b227-6a5c-422c-a7fb-23b3cc261cee)

After:
![i3lrYsndKZ](https://github.com/rainmeter/rainmeter/assets/35318437/4677338c-24df-44d9-9a23-bdd18556998b)

Note that I don't fully understand the codebase yet and the fix was found through trial and error.