### PR TITLE
!ToggleConfig any args count

### DIFF
--- a/Library/CommandHandler.cpp
+++ b/Library/CommandHandler.cpp
@@ -683,22 +683,26 @@ void CommandHandler::DoDeactivateSkinBang(std::vector<std::wstring>& args, Skin*
 
 void CommandHandler::DoToggleSkinBang(std::vector<std::wstring>& args, Skin* skin)
 {
-	if (args.size() >= 2)
+	if (skin)
 	{
-		Skin* skin = GetRainmeter().GetSkin(args[0]);
-		if (skin)
-		{
-			GetRainmeter().DeactivateSkin(skin, -1);
-			return;
-		}
-
-		// If the skin wasn't active, activate it.
-		DoActivateSkinBang(args, nullptr);
+		GetRainmeter().DeactivateSkin(skin, -1);
+		return;
 	}
 	else
 	{
-		LogErrorF(skin, L"!ToggleConfig: Invalid parameters");
+		if (args.size() == 1)
+		{
+			GetRainmeter().ActivateSkin(args[0]);
+			return;
+		}
+		else if (args.size > 1)
+		{
+			GetRainmeter().ActivateSkin(args[0],args[1]);
+			return;
+		}
 	}
+	
+	LogErrorF(skin, L"!ToggleConfig: Invalid parameters");
 }
 
 void CommandHandler::DoDeactivateSkinGroupBang(std::vector<std::wstring>& args, Skin* skin)


### PR DESCRIPTION
The !ToggleConfig bang may now be called supplied only with a config, similarly to the !DeactivateConfig bang which it supposedly depends on.

Currently, calling !ToggleConfig without specifying a file will result in an error, despite the functionality being present in the two underlying bangs which it should rely on.

I have severely limited myself and my style, as to fit that of the rest of the code. Otherwise, I would have compacted this and made it a lot more modular.

In any case, I wish for this bug to be fixed.


Besides, please note that this has been an issue for 11 years, as stated [here](https://forum.rainmeter.net/viewtopic.php?p=216773#p216773).