### PR TITLE
Repeat Feature for Measures and Meters

### DIFF
--- a/Library/ConfigParser.cpp
+++ b/Library/ConfigParser.cpp
@@ -2213,7 +2213,7 @@ const std::wstring& ConfigParser::GetValue(const std::wstring& strSection, const
 ** Copies all values based on section name
 ** replace #i# with count value
 */
-void ConfigParser::CopySectionValuesWithRepeat(const std::wstring& fromSection, const std::wstring& toSection, uint32_t count)
+void ConfigParser::CopySectionValuesWithReplace(const std::wstring& fromSection, const std::wstring& toSection, uint32_t count)
 {
 	std::wstring strFrom;
 	strFrom.reserve(fromSection.size() + 1ULL);

--- a/Library/ConfigParser.cpp
+++ b/Library/ConfigParser.cpp
@@ -2265,29 +2265,28 @@ void ConfigParser::DeleteSectionValues(const std::wstring& section)
 ** Insert Section 
 ** 
 */
-void ConfigParser::SectionInsert(const std::wstring& fromSection, const std::wstring& toSection)
+void ConfigParser::InsertSection(const std::wstring& fromSection, const std::wstring& toSection)
 {
+	const WCHAR* nameFrom = fromSection.c_str();
+
 	// Find the appropriate insertion place
 	for (std::list<std::wstring>::const_iterator jt = m_Sections.cbegin(); jt != m_Sections.cend(); ++jt)
 	{
-		if (_wcsicmp((*jt).c_str(), fromSection.c_str()) == 0)
+		if (_wcsicmp((*jt).c_str(), nameFrom) == 0)
 		{
-			LogDebugF(L"Found!: [%s => %s]", fromSection.c_str(), toSection.c_str());
-
 			StrToUpper(toSection);
 			m_Sections.insert(++jt, toSection);
 
-			//			m_SectionInsertPos = ++jt;
-			//			if (m_FoundSections.insert(fromSection).first)
-			//			{
-			//				m_Sections.insert(m_SectionInsertPos, fromSection);
-			//			}
 			break;
 		}
 	}
 }
 
-void ConfigParser::SectionDelete(const std::wstring& section)
+/*
+** Delete Section
+**
+*/
+void ConfigParser::DeleteSection(const std::wstring& section)
 {
 	const WCHAR* name = section.c_str();
 
@@ -2295,7 +2294,6 @@ void ConfigParser::SectionDelete(const std::wstring& section)
 	{
 		if (_wcsicmp((*jt).c_str(), name) == 0)
 		{
-			LogDebugF(L"DELTE!: %s", name);
 			m_Sections.erase(jt);
 			break;
 		}

--- a/Library/ConfigParser.cpp
+++ b/Library/ConfigParser.cpp
@@ -2260,3 +2260,44 @@ void ConfigParser::DeleteSectionValues(const std::wstring& section)
 		}
 	}
 }
+
+/*
+** Insert Section 
+** 
+*/
+void ConfigParser::SectionInsert(const std::wstring& fromSection, const std::wstring& toSection)
+{
+	// Find the appropriate insertion place
+	for (std::list<std::wstring>::const_iterator jt = m_Sections.cbegin(); jt != m_Sections.cend(); ++jt)
+	{
+		if (_wcsicmp((*jt).c_str(), fromSection.c_str()) == 0)
+		{
+			LogDebugF(L"Found!: [%s => %s]", fromSection.c_str(), toSection.c_str());
+
+			StrToUpper(toSection);
+			m_Sections.insert(++jt, toSection);
+
+			//			m_SectionInsertPos = ++jt;
+			//			if (m_FoundSections.insert(fromSection).first)
+			//			{
+			//				m_Sections.insert(m_SectionInsertPos, fromSection);
+			//			}
+			break;
+		}
+	}
+}
+
+void ConfigParser::SectionDelete(const std::wstring& section)
+{
+	const WCHAR* name = section.c_str();
+
+	for (std::list<std::wstring>::const_iterator jt = m_Sections.cbegin(); jt != m_Sections.cend(); ++jt)
+	{
+		if (_wcsicmp((*jt).c_str(), name) == 0)
+		{
+			LogDebugF(L"DELTE!: %s", name);
+			m_Sections.erase(jt);
+			break;
+		}
+	}
+}

--- a/Library/ConfigParser.cpp
+++ b/Library/ConfigParser.cpp
@@ -2211,27 +2211,9 @@ const std::wstring& ConfigParser::GetValue(const std::wstring& strSection, const
 
 /*
 ** Copies all values based on section name
-**
+** replace #i# with count value
 */
-
-void ConfigParser::CopySection(const std::wstring& fromSection, const std::wstring& toSection)
-{
-	std::wstring strFrom;
-	strFrom.reserve(fromSection.size() + 1ULL);
-	strFrom = StrToUpper(fromSection);
-	strFrom += L'~';
-
-	for (auto &iter = m_Values.begin(); iter != m_Values.end(); ++iter) {
-		if (iter->first.compare(0, strFrom.size(), strFrom) == 0) {
-			size_t pos = iter->first.find(L'~');
-			std::wstring strKey = iter->first.substr(pos + 1ULL);
-			//LogDebugF(L"CopySection: [%s->%s] %s => %s", fromSection.c_str(), toSection.c_str(), strKey, iter->second.c_str());
-			SetValue(toSection, strKey, (*iter).second);
-		}
-	}
-}
-
-void ConfigParser::CopySectionRepeater(const std::wstring& fromSection, const std::wstring& toSection, uint32_t count)
+void ConfigParser::CopySectionWithRepeat(const std::wstring& fromSection, const std::wstring& toSection, uint32_t count)
 {
 	std::wstring strFrom;
 	strFrom.reserve(fromSection.size() + 1ULL);
@@ -2247,13 +2229,11 @@ void ConfigParser::CopySectionRepeater(const std::wstring& fromSection, const st
 			std::wstring strKey = iter->first.substr(pos + 1ULL);
 			std::wstring strValue = iter->second;
 
-			//LogDebugF(L"CopySection: [%s->%s] %s => %s", fromSection.c_str(), toSection.c_str(), strKey, iter->second.c_str());
-
 			pos = 0;			
 			while ((pos = strValue.find(L"#i#", pos)) != std::string::npos)
 			{
 				strValue.replace(pos, 3, buffer);
-				pos += 3; // buffer.length() ?
+				pos += 3;
 			}
 
 			SetValue(toSection, strKey, strValue);

--- a/Library/ConfigParser.cpp
+++ b/Library/ConfigParser.cpp
@@ -2213,7 +2213,7 @@ const std::wstring& ConfigParser::GetValue(const std::wstring& strSection, const
 ** Copies all values based on section name
 ** replace #i# with count value
 */
-void ConfigParser::CopySectionWithRepeat(const std::wstring& fromSection, const std::wstring& toSection, uint32_t count)
+void ConfigParser::CopySectionValuesWithRepeat(const std::wstring& fromSection, const std::wstring& toSection, uint32_t count)
 {
 	std::wstring strFrom;
 	strFrom.reserve(fromSection.size() + 1ULL);
@@ -2236,7 +2236,27 @@ void ConfigParser::CopySectionWithRepeat(const std::wstring& fromSection, const 
 				pos += 3;
 			}
 
+			//LogDebugF(L"CopySect: %u [%s => %s] %s => %s", count, fromSection.c_str(), toSection.c_str(), strKey.c_str(), strValue.c_str());
+
 			SetValue(toSection, strKey, strValue);
+		}
+	}
+}
+
+/*
+** Delete all values based on section name
+** 
+*/
+void ConfigParser::DeleteSectionValues(const std::wstring& section)
+{
+	std::wstring strFrom;
+	strFrom.reserve(section.size() + 1ULL);
+	strFrom = StrToUpper(section);
+	strFrom += L'~';
+
+	for (auto& iter = m_Values.begin(); iter != m_Values.end(); ++iter) {
+		if (iter->first.compare(0, strFrom.size(), strFrom) == 0) {
+			m_Values.erase(iter);
 		}
 	}
 }

--- a/Library/ConfigParser.cpp
+++ b/Library/ConfigParser.cpp
@@ -2208,3 +2208,55 @@ const std::wstring& ConfigParser::GetValue(const std::wstring& strSection, const
 	std::unordered_map<std::wstring, std::wstring>::const_iterator iter = m_Values.find(StrToUpperC(strTmp));
 	return (iter != m_Values.end()) ? (*iter).second : strDefault;
 }
+
+/*
+** Copies all values based on section name
+**
+*/
+
+void ConfigParser::CopySection(const std::wstring& fromSection, const std::wstring& toSection)
+{
+	std::wstring strFrom;
+	strFrom.reserve(fromSection.size() + 1ULL);
+	strFrom = StrToUpper(fromSection);
+	strFrom += L'~';
+
+	for (auto &iter = m_Values.begin(); iter != m_Values.end(); ++iter) {
+		if (iter->first.compare(0, strFrom.size(), strFrom) == 0) {
+			size_t pos = iter->first.find(L'~');
+			std::wstring strKey = iter->first.substr(pos + 1ULL);
+			//LogDebugF(L"CopySection: [%s->%s] %s => %s", fromSection.c_str(), toSection.c_str(), strKey, iter->second.c_str());
+			SetValue(toSection, strKey, (*iter).second);
+		}
+	}
+}
+
+void ConfigParser::CopySectionRepeater(const std::wstring& fromSection, const std::wstring& toSection, uint32_t count)
+{
+	std::wstring strFrom;
+	strFrom.reserve(fromSection.size() + 1ULL);
+	strFrom = StrToUpper(fromSection);
+	strFrom += L'~';
+	
+	WCHAR buffer[3];
+	_snwprintf_s(buffer, _TRUNCATE, L"%u", count);
+
+	for (auto& iter = m_Values.begin(); iter != m_Values.end(); ++iter) {
+		if (iter->first.compare(0, strFrom.size(), strFrom) == 0) {
+			size_t pos = iter->first.find(L'~');
+			std::wstring strKey = iter->first.substr(pos + 1ULL);
+			std::wstring strValue = iter->second;
+
+			//LogDebugF(L"CopySection: [%s->%s] %s => %s", fromSection.c_str(), toSection.c_str(), strKey, iter->second.c_str());
+
+			pos = 0;			
+			while ((pos = strValue.find(L"#i#", pos)) != std::string::npos)
+			{
+				strValue.replace(pos, 3, buffer);
+				pos += 3; // buffer.length() ?
+			}
+
+			SetValue(toSection, strKey, strValue);
+		}
+	}
+}

--- a/Library/ConfigParser.h
+++ b/Library/ConfigParser.h
@@ -119,9 +119,9 @@ public:
 	static bool IsVariableKey(const WCHAR ch) { for (auto& k : c_VariableMap) { if (k.second == ch) return true; } return false; }
 
 	void CopySectionValuesWithReplace(const std::wstring& fromSection, const std::wstring& toSection, uint32_t count);
+	void InsertSection(const std::wstring& fromSection, const std::wstring& toSection);
+	void DeleteSection(const std::wstring& section);
 	void DeleteSectionValues(const std::wstring& section);
-	void SectionInsert(const std::wstring& fromSection, const std::wstring& toSection);
-	void SectionDelete(const std::wstring& section);
 
 private:
 	void SetBuiltInVariables(const std::wstring& filename, const std::wstring* resourcePath, Skin* skin);

--- a/Library/ConfigParser.h
+++ b/Library/ConfigParser.h
@@ -118,7 +118,7 @@ public:
 	static void UpdateWorkareaVariables() { SetMultiMonitorVariables(false); }
 	static bool IsVariableKey(const WCHAR ch) { for (auto& k : c_VariableMap) { if (k.second == ch) return true; } return false; }
 
-	void CopySectionValuesWithRepeat(const std::wstring& fromSection, const std::wstring& toSection, uint32_t count);
+	void CopySectionValuesWithReplace(const std::wstring& fromSection, const std::wstring& toSection, uint32_t count);
 	void DeleteSectionValues(const std::wstring& section);
 
 private:

--- a/Library/ConfigParser.h
+++ b/Library/ConfigParser.h
@@ -118,7 +118,8 @@ public:
 	static void UpdateWorkareaVariables() { SetMultiMonitorVariables(false); }
 	static bool IsVariableKey(const WCHAR ch) { for (auto& k : c_VariableMap) { if (k.second == ch) return true; } return false; }
 
-	void CopySectionWithRepeat(const std::wstring& fromSection, const std::wstring& toSection, uint32_t count);
+	void CopySectionValuesWithRepeat(const std::wstring& fromSection, const std::wstring& toSection, uint32_t count);
+	void DeleteSectionValues(const std::wstring& section);
 
 private:
 	void SetBuiltInVariables(const std::wstring& filename, const std::wstring* resourcePath, Skin* skin);

--- a/Library/ConfigParser.h
+++ b/Library/ConfigParser.h
@@ -120,6 +120,8 @@ public:
 
 	void CopySectionValuesWithReplace(const std::wstring& fromSection, const std::wstring& toSection, uint32_t count);
 	void DeleteSectionValues(const std::wstring& section);
+	void SectionInsert(const std::wstring& fromSection, const std::wstring& toSection);
+	void SectionDelete(const std::wstring& section);
 
 private:
 	void SetBuiltInVariables(const std::wstring& filename, const std::wstring* resourcePath, Skin* skin);

--- a/Library/ConfigParser.h
+++ b/Library/ConfigParser.h
@@ -118,6 +118,11 @@ public:
 	static void UpdateWorkareaVariables() { SetMultiMonitorVariables(false); }
 	static bool IsVariableKey(const WCHAR ch) { for (auto& k : c_VariableMap) { if (k.second == ch) return true; } return false; }
 
+
+
+	void CopySection(const std::wstring& fromSection, const std::wstring& toSection);
+	void CopySectionRepeater(const std::wstring& fromSection, const std::wstring& toSection, uint32_t count);
+
 private:
 	void SetBuiltInVariables(const std::wstring& filename, const std::wstring* resourcePath, Skin* skin);
 

--- a/Library/ConfigParser.h
+++ b/Library/ConfigParser.h
@@ -118,10 +118,7 @@ public:
 	static void UpdateWorkareaVariables() { SetMultiMonitorVariables(false); }
 	static bool IsVariableKey(const WCHAR ch) { for (auto& k : c_VariableMap) { if (k.second == ch) return true; } return false; }
 
-
-
-	void CopySection(const std::wstring& fromSection, const std::wstring& toSection);
-	void CopySectionRepeater(const std::wstring& fromSection, const std::wstring& toSection, uint32_t count);
+	void CopySectionWithRepeat(const std::wstring& fromSection, const std::wstring& toSection, uint32_t count);
 
 private:
 	void SetBuiltInVariables(const std::wstring& filename, const std::wstring* resourcePath, Skin* skin);

--- a/Library/Meter.h
+++ b/Library/Meter.h
@@ -63,6 +63,7 @@ public:
 	void SetY(int y);
 
 	void SetRelativeMeter(Meter* meter) { m_RelativeMeter = meter; }
+	Meter* GetRelativeMeter() { return m_RelativeMeter; }
 
 	const Mouse& GetMouse() { return m_Mouse; }
 	bool HasMouseAction() { return m_Mouse.HasButtonAction() || m_Mouse.HasScrollAction(); }

--- a/Library/Skin.cpp
+++ b/Library/Skin.cpp
@@ -2697,7 +2697,7 @@ bool Skin::ReadSkin()
 						std::wstring sectionName = section;
 						sectionName += buffer;
 
-						m_Parser.CopySectionWithRepeat(section, sectionName, i);
+						m_Parser.CopySectionValuesWithRepeat(section, sectionName, i);
 
 						Measure* measure = Measure::Create(measureName.c_str(), this, sectionName.c_str());
 						if (measure)
@@ -2735,36 +2735,6 @@ bool Skin::ReadSkin()
 			const std::wstring& meterName = m_Parser.ReadString(section, L"Meter", L"", false);
 			if (!meterName.empty())
 			{
-				/*
-				if (repeat > 0) {
-					if (repeat > 100) {
-						repeat = 100;
-					}
-					WCHAR buffer[3];
-					m_Parser.DeleteValue(section, L"Repeat");
-
-					for (uint32_t i = 1U; i <= repeat; ++i) {
-						_snwprintf_s(buffer, _TRUNCATE, L"%u", i);
-						std::wstring sectionName = section;
-						sectionName += buffer;
-
-						m_Parser.CopySectionWithRepeat(section, sectionName, i);
-
-						Meter* meter = Meter::Create(meterName.c_str(), this, sectionName.c_str());
-						if (meter)
-						{
-							m_Meters.push_back(meter);
-
-							if (meter->GetTypeID() == TypeID<MeterButton>())
-							{
-								m_HasButtons = true;
-							}
-						}
-					}
-
-					continue;
-				}
-				*/
 				if (_wcsicmp(meterName.c_str(), L"Repeat") == 0) {
 					const std::wstring strMeter = meterName;
 					uint32_t count = m_Parser.ReadUInt(section, L"Count", 0U);
@@ -2783,7 +2753,7 @@ bool Skin::ReadSkin()
 							sectionName += buffer;
 							const std::wstring strMeterType = m_Parser.GetValue(repeatMeter, L"Meter", L"");
 
-							m_Parser.CopySectionWithRepeat(repeatMeter, sectionName, i);
+							m_Parser.CopySectionValuesWithRepeat(repeatMeter, sectionName, i);
 							
 							Meter* meter = Meter::Create(strMeterType.c_str(), this, sectionName.c_str());
 							if (meter)
@@ -2800,7 +2770,7 @@ bool Skin::ReadSkin()
 
 					for (auto& repeatMeter : repeatMeters)
 					{
-						m_Parser.SetValue(repeatMeter, L"Hidden", L"1");
+						m_Parser.DeleteSectionValues(repeatMeter);
 					}
 
 					continue;

--- a/Library/Skin.cpp
+++ b/Library/Skin.cpp
@@ -2752,9 +2752,7 @@ bool Skin::ReadSkin()
 							const std::wstring strMeterType = m_Parser.GetValue(repeatMeter, L"Meter", L"");
 
 							m_Parser.CopySectionValuesWithReplace(repeatMeter, sectionName, i);
-							
-							// TODO:???
-							m_Parser.SectionInsert(repeatMeter, sectionName);
+							m_Parser.InsertSection(repeatMeter, sectionName);
 
 							Meter* meter = Meter::Create(strMeterType.c_str(), this, sectionName.c_str());
 							if (meter)
@@ -2771,13 +2769,9 @@ bool Skin::ReadSkin()
 
 					for (auto& repeatMeter : repeatMeters)
 					{
-
-						// Might not be necessary?  keep anyway?
-						m_Parser.SectionDelete(repeatMeter);
-						
+						m_Parser.DeleteSection(repeatMeter);
 						m_Parser.DeleteSectionValues(repeatMeter);
 						DeleteMeter(repeatMeter);
-
 					}
 
 					continue;
@@ -3226,10 +3220,6 @@ void Skin::UpdateRelativeMeters()
 		{
 			// Container meters can only be relative to other non-contained meters
 			containers[meter] = meter;
-		}
-
-		if (previousMeter) {
-			LogDebugF(L"Releative!: %s: Prev: %s", meter->GetName(), previousMeter->GetName());
 		}
 
 		meter->SetRelativeMeter(previousMeter);
@@ -5613,12 +5603,6 @@ Meter* Skin::GetMeter(const std::wstring& meterName)
 	return nullptr;
 }
 
-bool Skin::IsNetworkMeasure(Measure* measure)
-{
-	return measure->GetTypeID() == TypeID<MeasureNet>() ||
-		measure->GetTypeID() == TypeID<MeasureSysInfo>();
-}
-
 void Skin::DeleteMeter(const std::wstring& meterName)
 {
 	const WCHAR* name = meterName.c_str();
@@ -5635,4 +5619,10 @@ void Skin::DeleteMeter(const std::wstring& meterName)
 			m_Meters.erase(j);
 		}
 	}
+}
+
+bool Skin::IsNetworkMeasure(Measure* measure)
+{
+	return measure->GetTypeID() == TypeID<MeasureNet>() ||
+		measure->GetTypeID() == TypeID<MeasureSysInfo>();
 }

--- a/Library/Skin.cpp
+++ b/Library/Skin.cpp
@@ -2647,7 +2647,6 @@ bool Skin::ReadSkin()
 	// to avoid errors caused by referencing nonexistent [sections] in the options.
 	m_HasNetMeasures = false;
 	m_HasButtons = false;
-	//uint32_t repeat = 0;
 
 	for (auto iter = m_Parser.GetSections().cbegin(); iter != m_Parser.GetSections().cend(); ++iter)
 	{
@@ -2657,8 +2656,6 @@ bool Skin::ReadSkin()
 			_wcsicmp(L"Variables", section) != 0 &&
 			_wcsicmp(L"Metadata", section) != 0)
 		{
-			//repeat = m_Parser.ReadUInt(section, L"Repeat", 0U);
-
 			std::wstring measureName = m_Parser.ReadString(section, L"Measure", L"", false);
 			if (!measureName.empty())
 			{
@@ -2684,6 +2681,7 @@ bool Skin::ReadSkin()
 						}
 					}
 				}
+
 				uint32_t repeat = m_Parser.ReadUInt(section, L"Repeat", 0U);
 				if (repeat > 0) {
 					if (repeat > 100) {
@@ -2697,7 +2695,7 @@ bool Skin::ReadSkin()
 						std::wstring sectionName = section;
 						sectionName += buffer;
 
-						m_Parser.CopySectionValuesWithRepeat(section, sectionName, i);
+						m_Parser.CopySectionValuesWithReplace(section, sectionName, i);
 
 						Measure* measure = Measure::Create(measureName.c_str(), this, sectionName.c_str());
 						if (measure)
@@ -2753,7 +2751,7 @@ bool Skin::ReadSkin()
 							sectionName += buffer;
 							const std::wstring strMeterType = m_Parser.GetValue(repeatMeter, L"Meter", L"");
 
-							m_Parser.CopySectionValuesWithRepeat(repeatMeter, sectionName, i);
+							m_Parser.CopySectionValuesWithReplace(repeatMeter, sectionName, i);
 							
 							Meter* meter = Meter::Create(strMeterType.c_str(), this, sectionName.c_str());
 							if (meter)

--- a/Library/Skin.h
+++ b/Library/Skin.h
@@ -221,6 +221,7 @@ public:
 	Gfx::FontCollection* GetFontCollection() { return m_FontCollection; }
 
 	Meter* GetMeter(const std::wstring& meterName);
+	void DeleteMeter(const std::wstring& meterName);
 	Measure* GetMeasure(const std::wstring& measureName) { return m_Parser.GetMeasure(measureName); }
 
 	friend class DialogManage;


### PR DESCRIPTION
This pr requests adds the ability to repeat measures and groups of meters.  The need for this should be obvious to any one who has tried to create any sort of list or table.  eg. Currently, 5 measures x 10 rows is 50 measures you have to create.  Yuck.  Add the 50 meters needed to display that and, well, no thanks!  This pr fixes that.

### Measures
Adds a "Reapeat=X" option where X is the number of times to repeat (starting at 1)
Measures will be created with the X suffix and 
#i# will be replaced in the measures options with X as well.

Example
```
; In your Meter.ini

[MeasureQuote]
Measure=WebParser
URL=#URLPrefix##Ticker#i##
Repeat=2
```
Would result in...
```
[MeasureQuote1]
Measure=WebParser
URL=#URLPrefix##Ticker1#

[MeasureQuote2]
Measure=WebParser
URL=#URLPrefix##Ticker2#
```

### Meters
Adds a Meter=Repeat that has two options
 - Count=X (the number of times for the group to repeat, starting at 1)
 - RepeatMeters=[comma separated list of meternames]
Like measures any #i# in Meter options will be replace with the Count value

Example:
```
; In your Meter.ini

[MeterQuoteName]
Meter=String
MeasureName=MeasureQuoteName#i#

[MeterQuotePrice]
Meter=String
MeasureName=MeasureQuotePrice#i#

[MeterRepeat]
Meter=Repeat
Count=2
RepeatMeters=MeterQuoteName,MeterQuotePrice
```
would result in
```
[MeterQuoteName1]
Meter=String
MeasureName=MeasureQuoteName1

[MeterQuotePrice1]
Meter=String
MeasureName=MeasureQuotePrice1

[MeterQuoteName2]
Meter=String
MeasureName=MeasureQuoteName2

[MeterQuotePrice2]
Meter=String
MeasureName=MeasureQuotePrice2
```

### Anyway
I've attached a Test.ini
A Test Meter demonstrating these features.
[Test.ini.txt](https://github.com/user-attachments/files/17106408/Test.ini.txt)

Output of test meter (the ugly square) and what I actually created this for a table of quotes that doesn't need 5k measures and meters to do it!
![example2](https://github.com/user-attachments/assets/068d41d9-1df2-455d-a2ab-1f6ecd8f2ca5)
