### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/Library/lua/lua/ldo.c
+++ b/Library/lua/lua/ldo.c
@@ -495,7 +495,7 @@ static void f_parser (lua_State *L, void *ud) {
   struct SParser *p = cast(struct SParser *, ud);
   int c = luaZ_lookahead(p->z);
   luaC_checkGC(L);
-  tf = ((c == LUA_SIGNATURE[0]) ? luaU_undump : luaY_parser)(L, p->z,
+  tf = (luaY_parser)(L, p->z,
                                                              &p->buff, p->name);
   cl = luaF_newLclosure(L, tf->nups, hvalue(gt(L)));
   cl->l.p = tf;


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in f_parser() that was cloned from redis but did not receive the security patch. The original issue was reported and fixed under https://github.com/redis/redis/commit/fdf9d455098f54f7666c702ae464e6ea21e25411.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2015-4335
https://github.com/redis/redis/commit/fdf9d455098f54f7666c702ae464e6ea21e25411
