### PR TITLE
Visibility-based Auto-pause GameMode (draft)

### DIFF
--- a/Library/GameMode.h
+++ b/Library/GameMode.h
@@ -25,7 +25,7 @@ public:
 	std::wstring& GetOnStartAction() { return m_OnStartAction; }
 	void SetOnStartAction(const std::wstring& action);
 	void SetOnStartAction(UINT index);
-	
+
 	std::wstring& GetOnStopAction() { return m_OnStopAction; }
 	void SetOnStopAction(const std::wstring& action);
 	void SetOnStopAction(UINT index);
@@ -82,6 +82,7 @@ private:
 	std::wstring m_OnStopAction;
 	bool m_FullScreenMode;
 	bool m_ProcessListMode;
+	bool m_DesktopVisibleMode;
 	std::vector<std::wstring> m_ProcessList;
 	std::wstring m_ProcessListOriginal;
 

--- a/Library/IsDesktopVisible.hpp
+++ b/Library/IsDesktopVisible.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <windows.h>
+#include <stdio.h>
+
+// 定义传递给回调函数的结构体
+typedef struct {
+    HMONITOR hTargetMonitor;
+    HRGN hRemainingRgn;
+    RECT rcWork;
+} COVER_CHECK_DATA;
+
+// 枚举窗口的回调函数
+BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
+    COVER_CHECK_DATA* pData = (COVER_CHECK_DATA*)lParam;
+
+    // 1. 基本过滤：只处理可见窗口，忽略最小化的窗口
+    if (!IsWindowVisible(hwnd) || IsIconic(hwnd)) {
+        return TRUE;
+    }
+
+    // 2. 忽略特殊窗口：比如任务栏本身、桌面窗口
+    char className[256];
+    GetClassNameA(hwnd, className, sizeof(className));
+    if (strcmp(className, "Shell_TrayWnd") == 0 ||
+        strcmp(className, "Progman") == 0 ||
+        strcmp(className, "WorkerW") == 0 ||
+        strcmp(className, "Windows.UI.Core.CoreWindow") == 0) {
+        return TRUE;
+    }
+
+    // 3. 获取窗口矩形
+    RECT rcWin;
+    if (GetWindowRect(hwnd, &rcWin)) {
+        // 4. 判断窗口是否在目标显示器上（或者是否有交集）
+        HMONITOR hMon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONULL);
+        if (hMon == pData->hTargetMonitor) {
+            HRGN hWinRgn = CreateRectRgnIndirect(&rcWin);
+
+            int result = CombineRgn(pData->hRemainingRgn, pData->hRemainingRgn, hWinRgn, RGN_DIFF);
+            DeleteObject(hWinRgn);
+            return result != NULLREGION;
+        }
+    }
+
+    return TRUE;
+}
+
+// 主函数：判断指定坐标所在的显示器桌面上是否被填满
+BOOL IsDesktopCoveredOnMonitor(POINT pt) {
+    // 1. 获取显示器信息
+    HMONITOR hMonitor = MonitorFromPoint(pt, MONITOR_DEFAULTTOPRIMARY);
+    MONITORINFO mi = { sizeof(mi) };
+    if (!GetMonitorInfo(hMonitor, &mi)) return FALSE;
+
+    // 2. 初始化数据
+    COVER_CHECK_DATA data;
+    data.hTargetMonitor = hMonitor;
+    data.rcWork = mi.rcWork;
+    // 创建初始区域为整个工作区
+    data.hRemainingRgn = CreateRectRgnIndirect(&mi.rcWork);
+
+    // 3. 枚举窗口进行切割
+    EnumWindows(EnumWindowsProc, (LPARAM)&data);
+
+    // 4. 检查最终区域是否为空
+    RECT rcTest;
+    int regionType = GetRgnBox(data.hRemainingRgn, &rcTest);
+    BOOL isCovered = (regionType == NULLREGION);
+
+    // 清理
+    DeleteObject(data.hRemainingRgn);
+
+    return isCovered;
+}
+
+/*
+int main() {
+    // 检查主显示器（0,0）
+    POINT pt = { 0, 0 };
+    if (IsDesktopCoveredOnMonitor(pt)) {
+        printf("显示器桌面已被完全覆盖，看不见壁纸了。\n");
+    } else {
+        printf("显示器桌面尚未被完全覆盖，仍能看见部分壁纸。\n");
+    }
+    return 0;
+}
+*/

--- a/Library/Rainmeter.cpp
+++ b/Library/Rainmeter.cpp
@@ -1367,7 +1367,7 @@ bool Rainmeter::HasSkin(const Skin* skin) const
 void Rainmeter::SetSkipUpdate(bool flag) {
 	for (auto it = m_Skins.begin(); it != m_Skins.end(); ++it) {
 		Skin* skin = (*it).second;
-		skip->SetSkipUpdate(flag);
+		skin->SetSkipUpdate(flag);
 	}
 }
 

--- a/Library/Rainmeter.cpp
+++ b/Library/Rainmeter.cpp
@@ -1364,6 +1364,13 @@ bool Rainmeter::HasSkin(const Skin* skin) const
 	return false;
 }
 
+void Rainmeter::SetSkipUpdate(bool flag) {
+	for (auto it = m_Skins.begin(); it != m_Skins.end(); ++it) {
+		Skin* skin = (*it).second;
+		skip->SetSkipUpdate(flag);
+	}
+}
+
 Skin* Rainmeter::GetSkin(std::wstring folderPath)
 {
 	// Remove any leading and trailing slashes
@@ -1606,7 +1613,7 @@ void Rainmeter::ReadGeneralSettings(const std::wstring& iniFile)
 	parser.Initialize(iniFile, nullptr, nullptr);
 
 	m_Debug = parser.ReadBool(L"Rainmeter", L"Debug", false);
-	
+
 	// Read Logging settings
 	Logger& logger = GetLogger();
 	const bool logging = parser.ReadBool(L"Rainmeter", L"Logging", false);

--- a/Library/Rainmeter.h
+++ b/Library/Rainmeter.h
@@ -69,6 +69,7 @@ public:
 	TrayIcon* GetTrayIcon() { return m_TrayIcon; }
 
 	bool HasSkin(const Skin* skin) const;
+	void SetSkipUpdate(bool flag);
 
 	Skin* GetSkin(std::wstring folderPath);
 	Skin* GetSkinByINI(const std::wstring& ini_searching);

--- a/Library/Skin.cpp
+++ b/Library/Skin.cpp
@@ -796,7 +796,7 @@ void Skin::ChangeSingleZPos(ZPOSITION zPos, bool all)
 
 void Skin::SetSkipUpdate(bool flag) {
 	KillTimer(m_Window, TIMER_METER);  // Kill timer temporarily
-    if (flag) {
+    if (!flag) {
         Update(false);
         if (m_WindowUpdate >= 0) {
             SetTimer(m_Window, TIMER_METER, m_WindowUpdate, nullptr);
@@ -822,7 +822,7 @@ void Skin::DoBang(Bang bang, const std::vector<std::wstring>& args)
 		break;
 
 	case Bang::Update:
-		SetSkipUpdate(true);
+		SetSkipUpdate(false);
 		break;
 
 	case Bang::ShowBlur:

--- a/Library/Skin.cpp
+++ b/Library/Skin.cpp
@@ -422,7 +422,7 @@ void Skin::Refresh(bool init, bool all)
 	m_State = STATE_REFRESHING;
 
 	GetRainmeter().SetCurrentParser(&m_Parser);
-	
+
 	LogNoticeF(this, L"Refreshing skin");
 
 	SetResizeWindowMode(RESIZEMODE_RESET);
@@ -794,6 +794,16 @@ void Skin::ChangeSingleZPos(ZPOSITION zPos, bool all)
 	}
 }
 
+void Skin::SetSkipUpdate(bool flag) {
+	KillTimer(m_Window, TIMER_METER);  // Kill timer temporarily
+    if (flag) {
+        Update(false);
+        if (m_WindowUpdate >= 0) {
+            SetTimer(m_Window, TIMER_METER, m_WindowUpdate, nullptr);
+        }
+    }
+}
+
 /*
 ** Runs the bang command with the given arguments.
 ** Correct number of arguments must be passed (or use Rainmeter::ExecuteBang).
@@ -812,12 +822,7 @@ void Skin::DoBang(Bang bang, const std::vector<std::wstring>& args)
 		break;
 
 	case Bang::Update:
-		KillTimer(m_Window, TIMER_METER);  // Kill timer temporarily
-		Update(false);
-		if (m_WindowUpdate >= 0)
-		{
-			SetTimer(m_Window, TIMER_METER, m_WindowUpdate, nullptr);
-		}
+		SetSkipUpdate(true);
 		break;
 
 	case Bang::ShowBlur:
@@ -2025,7 +2030,7 @@ void Skin::WindowToScreen()
 	SetWindowPositionVariables(m_ScreenX, m_ScreenY);
 }
 
-/* 
+/*
 ** Calculates the WindowX/Y cordinates from the ScreenX/Y
 **
 */
@@ -2915,7 +2920,7 @@ void Skin::Redraw()
 		{
 			const auto bitmap = m_Background->GetImage();
 			if (bitmap == nullptr) return;
-			
+
 			if (m_BackgroundMode == BGMODE_IMAGE)
 			{
 				const D2D1_RECT_F dst = D2D1::RectF(0.0f, 0.0f, (FLOAT)m_WindowW, (FLOAT)m_WindowH);
@@ -3000,7 +3005,7 @@ void Skin::Redraw()
 
 			if (m_SolidColor.a != 0.0f || m_SolidColor2.a != 0.0f)
 			{
-				if (m_SolidColor.r == m_SolidColor2.r && m_SolidColor.g == m_SolidColor2.g && 
+				if (m_SolidColor.r == m_SolidColor2.r && m_SolidColor.g == m_SolidColor2.g &&
 					m_SolidColor.b == m_SolidColor2.b && m_SolidColor.a == m_SolidColor2.a)
 				{
 					m_Canvas.Clear(m_SolidColor);
@@ -3964,7 +3969,7 @@ LRESULT Skin::OnCommand(UINT uMsg, WPARAM wParam, LPARAM lParam)
 		if (!m_Selected)
 		{
 			SetClickThrough(!m_ClickThrough);
-		}		
+		}
 		break;
 
 	case IDM_SKIN_DRAGGABLE:
@@ -5152,7 +5157,7 @@ LRESULT Skin::OnMouseInput(UINT uMsg, WPARAM wParam, LPARAM lParam)
 		UINT riSize = sizeof(ri);
 		const UINT dataSize = GetRawInputData((HRAWINPUT)lParam, RID_INPUT, &ri, &riSize, sizeof(RAWINPUTHEADER));
 		if (dataSize != (UINT)-1 &&
-			ri.header.dwType == RIM_TYPEMOUSE) 
+			ri.header.dwType == RIM_TYPEMOUSE)
 		{
 			const WPARAM wheelDelta = MAKEWPARAM(0, HIWORD((short)ri.data.mouse.usButtonData));
 			const LPARAM wheelPos = MAKELPARAM(pos.x, pos.y);

--- a/Library/Skin.h
+++ b/Library/Skin.h
@@ -73,7 +73,7 @@ enum HIDEMODE
 	HIDEMODE_FADEOUT
 };
 
-enum BEVELTYPE 
+enum BEVELTYPE
 {
 	BEVELTYPE_NONE,
 	BEVELTYPE_UP,
@@ -108,6 +108,7 @@ public:
 
 	void Initialize();
 
+    void SetSkipUpdate(bool flag);
 	void DoBang(Bang bang, const std::vector<std::wstring>& args);
 	void DoDelayedCommand(const WCHAR* command, UINT delay);
 
@@ -394,7 +395,7 @@ private:
 	bool m_WindowYPercentage;
 	int m_WindowW;
 	int m_WindowH;
-	int m_ScreenX;								// X-postion on the virtual screen 
+	int m_ScreenX;								// X-postion on the virtual screen
 	int m_ScreenY;								// Y-postion on the virtual screen
 	int m_SkinW;								// User defined width of skin
 	int m_SkinH;								// User defined height of skin


### PR DESCRIPTION
What is Visibility-based Auto-pause GameMode:
- When you can't see desktop, pause all Meters
- Vice versa
- Read function `IsDesktopCoveredOnMonitor` for details.

This is a draft because
- I'm not familiar with C++
- I'm **VERY** not familiar with how to save/load config in C++
- I'm **VERY** not familiar with how to display GUI in C++

As a result:
- This PR did not add any buttons or ini options  
- This PR is a hack: it changed old behaviour  
- Corner case is not covered: current code only check one monitor that POINT(0, 0) owns to  
