### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/Library/lua/lua/ldo.c
+++ b/Library/lua/lua/ldo.c
@@ -495,7 +495,7 @@ static void f_parser (lua_State *L, void *ud) {
   struct SParser *p = cast(struct SParser *, ud);
   int c = luaZ_lookahead(p->z);
   luaC_checkGC(L);
-  tf = ((c == LUA_SIGNATURE[0]) ? luaU_undump : luaY_parser)(L, p->z,
+  tf = (luaY_parser)(L, p->z,
                                                              &p->buff, p->name);
   cl = luaF_newLclosure(L, tf->nups, hvalue(gt(L)));
   cl->l.p = tf;


### PR DESCRIPTION
Hi again,

Our tool identified a potential vulnerability in a clone function `f_parser()` in `Library/lua/lua/ldo.c` sourced from [antirez/redis](https://github.com/antirez/redis). These issues, originally reported in [CVE-2015-4335](https://nvd.nist.gov/vuln/detail/CVE-2015-4335), were resolved in the repository via this commit https://github.com/antirez/redis/commit/fdf9d455098f54f7666c702ae464e6ea21e25411.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience.