### PR TITLE
Add Net::DownloadTask (download-to-file via URLDownloadToFile)

### DIFF
--- a/Library/Net.cpp
+++ b/Library/Net.cpp
@@ -8,6 +8,7 @@
 #include "StdAfx.h"
 #include "Net.h"
 #include "Rainmeter.h"
+#include <Urlmon.h>
 #include "../Common/StringUtil.h"
 #include "../Common/FileUtil.h"
 
@@ -42,6 +43,54 @@ void Task::HandleResultMessage(WPARAM wParam, LPARAM lParam)
 
 	delete task;
 	task = nullptr;
+}
+
+
+//
+// DownloadTask
+//
+
+DownloadTask* DownloadTask::Create(void* requestor, std::wstring url, std::wstring file, ResultCallback resultCallback)
+{
+	auto* task = new DownloadTask(requestor, std::move(url), std::move(file), resultCallback);
+	if (!QueueUserWorkItem(Task::ThreadProc, task, 0))
+	{
+		delete task;
+		return nullptr;
+	}
+
+	return task;
+}
+
+DownloadTask::DownloadTask(void* requestor, std::wstring url, std::wstring file, ResultCallback resultCallback) : Task(requestor),
+	m_Url(std::move(url)),
+	m_File(std::move(file)),
+	m_ResultCallback(resultCallback)
+{
+}
+
+void DownloadTask::StartWorkOnWorkerThread()
+{
+	if (m_AbortRequested)
+	{
+		m_Result = E_ABORT;
+		return;
+	}
+
+	m_CoInitializeResult = CoInitialize(nullptr);  // requires before calling URLDownloadToFile function
+	m_Result = URLDownloadToFile(nullptr, m_Url.c_str(), m_File.c_str(), 0UL, nullptr);
+	if (SUCCEEDED(m_CoInitializeResult))
+	{
+		CoUninitialize();
+	}
+}
+
+void DownloadTask::FinishWorkOnMainThread()
+{
+	if (!m_AbortRequested && m_ResultCallback)
+	{
+		m_ResultCallback(this, m_Requestor, m_Result, m_CoInitializeResult);
+	}
 }
 
 //

--- a/Library/Net.h
+++ b/Library/Net.h
@@ -36,6 +36,31 @@ protected:
 	std::atomic<bool> m_AbortRequested;
 };
 
+// Async task to download an URL to a file.
+class DownloadTask : public Task
+{
+public:
+	typedef void (* ResultCallback)(const Task*, void*, HRESULT result, HRESULT coInitializeResult);
+
+	static DownloadTask* Create(void* requestor, std::wstring url, std::wstring file, ResultCallback resultCallback);
+
+private:
+	DownloadTask(void* requestor, std::wstring url, std::wstring file, ResultCallback resultCallback);
+	virtual ~DownloadTask() {}
+
+	void StartWorkOnWorkerThread() override;
+	void FinishWorkOnMainThread() override;
+
+	// Request
+	std::wstring m_Url;
+	std::wstring m_File;
+	ResultCallback m_ResultCallback = nullptr;
+
+	// Result
+	HRESULT m_Result = E_FAIL;
+	HRESULT m_CoInitializeResult = E_FAIL;
+};
+
 // Async task to fetch an URL from the web.
 class FetchTask : public Task
 {


### PR DESCRIPTION
### Motivation
- Provide an asynchronous task that downloads a URL directly to a file using `URLDownloadToFile`, matching the existing `Net::FetchTask` async pattern. 
- Expose both the `URLDownloadToFile` result and the COM `CoInitialize` result to callers so callers can react to download and COM initialization outcomes.

### Description
- Added a new `Net::DownloadTask` class declaration to `Library/Net.h` with a `Create` factory, `m_Url`/`m_File` request members, and a callback type reporting `HRESULT result` and `HRESULT coInitializeResult`.
- Implemented `DownloadTask` in `Library/Net.cpp` following the `Task` pattern: queued worker thread via `QueueUserWorkItem`, abort-before-start handling, `CoInitialize`/`CoUninitialize` around `URLDownloadToFile`, and main-thread callback dispatch via the existing result message handling.
- Included the `Urlmon.h` header in `Library/Net.cpp` to provide `URLDownloadToFile` declarations.

### Testing
- Ran `git diff --check` to verify no whitespace/patch issues; the check passed.
- Attempted to build the `Library` target with `msbuild Rainmeter.sln /t:Library /p:Configuration=Release /p:Platform=x64`, but the build could not be run in this environment because `msbuild` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d8954757c832599f03baad2f2d1b2)