### PR TITLE
Typo: Fixed Language files for Installer - UnsupportedWindowsError

### DIFF
--- a/Language/ar.ini
+++ b/Language/ar.ini
@@ -207,7 +207,7 @@ InstallNewVersion=تثبيتُ النسخة الحديثة
 ClickToInstall=أعِد تشغيل البرنامج لتثبيت النسخة: %1
 
 [Installer]
-UnsupportedWindowsError=هذه النسخة ${VERSION_SHORT} لا تدعم ويندوز 7/8 لتشغيل البرنامج على ويندوز 7/8 قم بتنزيل الإصدار رقم 4.8 من البرنامج.
+UnsupportedWindowsError=هذه النسخة ${VERSION_SHORT} لا تدعم ويندوز 7/8 لتشغيل البرنامج على ويندوز 7/8 قم بتنزيل الإصدار رقم 4.5 من البرنامج.
 AdminError=صلاحيات إدارية مطلوبة.
 LogonError=خدمة تسجيل الدخول لا تعمل.
 UacError=غير قادر على التنشيط.

--- a/Language/bg.ini
+++ b/Language/bg.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Install new version
 ClickToInstall=Restart Rainmeter to install version: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} не поддържа Windows 7/8. За да използвате Rainmeter под Windows 7/8, свалете по-старата Rainmeter 4.8 версия.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} не поддържа Windows 7/8. За да използвате Rainmeter под Windows 7/8, свалете по-старата Rainmeter 4.5 версия.
 AdminError=Нужни са административни права.
 LogonError=Услугата Logon service не е стартирана.
 UacError=Нямате административни права.

--- a/Language/cs.ini
+++ b/Language/cs.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Nainstalovat novou verzi
 ClickToInstall=Restartovat Rainmeter a nainstalovat verzi: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} nepodporuje Windows 7/8. Pro použití Rainmeteru ve Windows 7/8 stáhněte starší verzi Rainmeter 4.8.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} nepodporuje Windows 7/8. Pro použití Rainmeteru ve Windows 7/8 stáhněte starší verzi Rainmeter 4.5.
 AdminError=Požadována administrátorská práva.
 LogonError=Služba přihlášení není spuštěna.
 UacError=Nelze upgradovat.

--- a/Language/da.ini
+++ b/Language/da.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Installer ny version
 ClickToInstall=Genstart Rainmeter for at installere version: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} understøtter ikke Windows 7/8. For at bruge Rainmeter på Windows 7/8 skal du hente den ældre Rainmeter 4.8 version.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} understøtter ikke Windows 7/8. For at bruge Rainmeter på Windows 7/8 skal du hente den ældre Rainmeter 4.5 version.
 AdminError=Adminstrative rettigheder påkrævet.
 LogonError=Logon service kører ikke.
 UacError=Kunne ikke elevere rettigheder.

--- a/Language/de.ini
+++ b/Language/de.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Installiere neue Version
 ClickToInstall=Starte Rainmeter neu um Version %1 zu installieren
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} unterstützt nicht Windows 7/8. Um Rainmeter unter Windows 7/8 zu verwenden, laden Sie die ältere Rainmeter Version 2.0 herunter.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} unterstützt nicht Windows 7/8. Um Rainmeter unter Windows 7/8 zu verwenden, laden Sie die ältere Rainmeter Version 4.5 herunter.
 AdminError=Benötigt Adminstratorrechte.
 LogonError=Logon Service läuft nicht.
 UacError=Ausführen mit erweiterten Rechten fehlgeschlagen.

--- a/Language/el.ini
+++ b/Language/el.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Εγκατάσταση νέας έκδοσης
 ClickToInstall=Επανεκκινήστε το Rainmeter για να εγκαταστήσετε την έκδοση: %1
 
 [Installer]
-UnsupportedWindowsError=Το Rainmeter ${VERSION_SHORT} δεν υποστηρίζει Windows 7/8. Για να χρησιμοποιήσετε το Rainmeter στα Windows 7/8, κατεβάστε την έκδοση 4.8 του Rainmeter.
+UnsupportedWindowsError=Το Rainmeter ${VERSION_SHORT} δεν υποστηρίζει Windows 7/8. Για να χρησιμοποιήσετε το Rainmeter στα Windows 7/8, κατεβάστε την έκδοση 4.5 του Rainmeter.
 AdminError=Χρειάζονται δικαιώματα διαχειριστή.
 LogonError=Η υπηρεσία Logon δεν λειτουργεί.
 UacError=Λάθος UAC. Αδύνατον να συνεχίσει.

--- a/Language/en.ini
+++ b/Language/en.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Install new version
 ClickToInstall=Restart Rainmeter to install version: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} does not support Windows 7/8. To use Rainmeter on Windows 7/8, download the older Rainmeter 4.8 version.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} does not support Windows 7/8. To use Rainmeter on Windows 7/8, download the older Rainmeter 4.5 version.
 AdminError=Adminstrative rights required.
 LogonError=Logon service not running.
 UacError=Unable to elevate.

--- a/Language/es.ini
+++ b/Language/es.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Instalar nueva versión
 ClickToInstall=Reiniciar Rainmeter para instalar versión: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} no es compatible con Windows 7/8. Para usar Rainmeter en Windows 7/8, descargar la versión antigua de Rainmeter 4.8.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} no es compatible con Windows 7/8. Para usar Rainmeter en Windows 7/8, descargar la versión antigua de Rainmeter 4.5.
 AdminError=Derechos de administrador son requeridos.
 LogonError=El servicio de inicio de sesión no se está ejecutando.
 UacError=No se puede elevar los privilegios.

--- a/Language/et.ini
+++ b/Language/et.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Paigalda uus versioon
 ClickToInstall=Taaskäivita Rainmeter, et paigaldada versioon: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} ei toeta operatsioonisüsteemi Windows 7/8. Palun lae alla vanem Rainmeter 4.8 versioon.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} ei toeta operatsioonisüsteemi Windows 7/8. Palun lae alla vanem Rainmeter 4.5 versioon.
 AdminError=Vaja on administraatoriõiguseid.
 LogonError=Sisselogimisteenus ei tööta.
 UacError=Kasutajakonto kontroll ebaõnnestus.

--- a/Language/fi.ini
+++ b/Language/fi.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Asenna uusi versio
 ClickToInstall=Käynnistä Rainmeter uudelleen asentaaksesi versio: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} ei enää tue Windows 7/8 versioita. Ole hyvä ja lataa vanhempi Rainmeter 4.8 versio.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} ei enää tue Windows 7/8 versioita. Ole hyvä ja lataa vanhempi Rainmeter 4.5 versio.
 AdminError=Tarvitaan järjestelmänvalvojan oikeudet.
 LogonError=Kirjautumispalvelu ei ole käynnissä.
 UacError=UAC korottaminen epäonnistui.

--- a/Language/fr.ini
+++ b/Language/fr.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Installer la nouvelle version
 ClickToInstall=Redémarrer Rainmeter pour installer la version : %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} ne supporte pas Windows 7/8. Veuillez télécharger une version antérieure à Rainmeter 4.8.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} ne supporte pas Windows 7/8. Veuillez télécharger une version antérieure à Rainmeter 4.5.
 AdminError=Droits administrateur requis.
 LogonError=Le service Logon n'est pas démarré.
 UacError=Impossible d'élever les privilèges.

--- a/Language/he.ini
+++ b/Language/he.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Install new version
 ClickToInstall=Restart Rainmeter to install version: %1
 
 [Installer]
-UnsupportedWindowsError=ריינמטר ${VERSION_SHORT} אינו תומך בחלונות 7/8. כדי להשתמש בריינמטר בחלונות 7/8, הורד את הגירסא הישנה ריינמטר 4.8.
+UnsupportedWindowsError=ריינמטר ${VERSION_SHORT} אינו תומך בחלונות 7/8. כדי להשתמש בריינמטר בחלונות 7/8, הורד את הגירסא הישנה ריינמטר 4.5.
 AdminError=נדרשות הרשאות ניהוליות.
 LogonError=שירות החיבור אינו מופעל.
 UacError=אינו מצליח לעלות.

--- a/Language/hr.ini
+++ b/Language/hr.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Install new version
 ClickToInstall=Restart Rainmeter to install version: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} ne podržava Windowse 7/8. Za korištenje Rainmetera na Windowsima 7/8, skinite stariju verziju, Rainmeter 4.8.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} ne podržava Windowse 7/8. Za korištenje Rainmetera na Windowsima 7/8, skinite stariju verziju, Rainmeter 4.5.
 AdminError=Potrebne su adminstrativne ovlasti.
 LogonError=Logon servis nije pokrenut.
 UacError=Nije moguće uzdići prava.

--- a/Language/hu.ini
+++ b/Language/hu.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Új verzió telepítése
 ClickToInstall=Indítsd újra a Rainmeter-t az új verzió telepítéséhez: %1
 
 [Installer]
-UnsupportedWindowsError=A Rainmeter ${VERSION_SHORT} nem támogatja a Windows 7/8 operációs rendszert. A program használatához töltsd le a korábbi Rainmeter 4.8 verziót.
+UnsupportedWindowsError=A Rainmeter ${VERSION_SHORT} nem támogatja a Windows 7/8 operációs rendszert. A program használatához töltsd le a korábbi Rainmeter 4.5 verziót.
 AdminError=Rendszergazdai engedély szükséges
 LogonError=A bejelentkezési szolgáltatás nem fut.
 UacError=Jogosultságemelés nem lehetséges

--- a/Language/id.ini
+++ b/Language/id.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Pasang versi baru
 ClickToInstall=Mulai ulang Rainmeter untuk memasang versi: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} tidak mendukung Windows 7/8. Untuk menggunakan Rainmeter di Windows 7/8, unduh versi lama Rainmeter 4.8.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} tidak mendukung Windows 7/8. Untuk menggunakan Rainmeter di Windows 7/8, unduh versi lama Rainmeter 4.5.
 AdminError=Hak administratif dibutuhkan.
 LogonError=Layanan logon tidak tersedia.
 UacError=Tidak dapat ditingkatkan.

--- a/Language/it.ini
+++ b/Language/it.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Installa la nuova versione
 ClickToInstall=Riavvia Rainmeter per installare la versione: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} non supporta Windows 7/8. Per usare Rainmeter su Windows 7/8, scaricare la versione obsoleta di Rainmeter 4.8.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} non supporta Windows 7/8. Per usare Rainmeter su Windows 7/8, scaricare la versione obsoleta di Rainmeter 4.5.
 AdminError=Richiesti diritti d'amministratore.
 LogonError=Servizio di login non disponibile.
 UacError=Impossibile alzare i privilegi.

--- a/Language/ja.ini
+++ b/Language/ja.ini
@@ -207,7 +207,7 @@ InstallNewVersion=最新版をインストール
 ClickToInstall=Rainmeterを再起動し、バージョン %1 をインストールする
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} は Windows 7/8 に対応していません。Rainmeter を Windows 7/8 で使用するには、バージョン 2.0 以前の Rainmeter をダウンロードしてください。
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} は Windows 7/8 に対応していません。Rainmeter を Windows 7/8 で使用するには、バージョン 4.5 以前の Rainmeter をダウンロードしてください。
 AdminError=管理者権限が必要です。
 LogonError=ログオンサービスが起動していません。
 UacError=権限の昇格に失敗しました。

--- a/Language/ko.ini
+++ b/Language/ko.ini
@@ -207,7 +207,7 @@ InstallNewVersion=새 버전 설치
 ClickToInstall=다음 버전을 설치하려면 Rainmeter를 다시 시작하세요: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT}은 Windows 7/8을 지원하지 않습니다. Windows 7/8에서 Rainmeter를 사용하려면 Rainmeter 4.8 이전 버전을 다운로드 하세요.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT}은 Windows 7/8을 지원하지 않습니다. Windows 7/8에서 Rainmeter를 사용하려면 Rainmeter 4.5 이전 버전을 다운로드 하세요.
 AdminError=관리자 권한이 필요합니다.
 LogonError=로그온 서비스가 실행 중이 아닙니다.
 UacError=권한 상승 실패.

--- a/Language/lt.ini
+++ b/Language/lt.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Install new version
 ClickToInstall=Restart Rainmeter to install version: %1
 
 [Installer]
-UnsupportedWindowsError='Rainmeter' ${VERSION_SHORT} nepalaiko 'Windows 7/8'. Norėdami naudoti 'Rainmeter' 'Windows 7/8' systemoje, atsisiųskite senesnę ''Rainmeter'' 4.8 versija.
+UnsupportedWindowsError='Rainmeter' ${VERSION_SHORT} nepalaiko 'Windows 7/8'. Norėdami naudoti 'Rainmeter' 'Windows 7/8' systemoje, atsisiųskite senesnę ''Rainmeter'' 4.5 versija.
 AdminError=Turite turėti administratoriaus teises.
 LogonError=Registravimosi tarnyba neveikia.
 UacError=Nepavyko sukelti teisių.

--- a/Language/lv.ini
+++ b/Language/lv.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Install new version
 ClickToInstall=Restart Rainmeter to install version: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter programa ${VERSION_SHORT} neatbalsta Windows 7/8. Lai izmantotu Rainmeter uz Windows 7/8 platformas, lejuplādējiet vecāku Rainmeter 4.8 programas versiju.
+UnsupportedWindowsError=Rainmeter programa ${VERSION_SHORT} neatbalsta Windows 7/8. Lai izmantotu Rainmeter uz Windows 7/8 platformas, lejuplādējiet vecāku Rainmeter 4.5 programas versiju.
 AdminError=Nepieciešamas administratora tiesības.
 LogonError='Logon service' nav ieslēgts.
 UacError=Nevar paaugstināt.

--- a/Language/ms.ini
+++ b/Language/ms.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Install new version
 ClickToInstall=Restart Rainmeter to install version: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} tidak menyokong Windows 7/8. Untuk guna Rainmeter dalam Windows 7/8, muat turun Rainmeter versi lama (4.8).
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} tidak menyokong Windows 7/8. Untuk guna Rainmeter dalam Windows 7/8, muat turun Rainmeter versi lama (4.5).
 AdminError=Hak pentadbiran diperlukan.
 LogonError=Perkhidmatan log masuk tidak berjalan.
 UacError=Tidak diluluskan UAC.

--- a/Language/nb.ini
+++ b/Language/nb.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Install new version
 ClickToInstall=Restart Rainmeter to install version: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} støtter ikke Windows 7/8. For å benytte Rainmeter på Windows 7/8, last ned den eldre versjonen, Rainmeter 4.8.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} støtter ikke Windows 7/8. For å benytte Rainmeter på Windows 7/8, last ned den eldre versjonen, Rainmeter 4.5.
 AdminError=Administratortilgang kreves.
 LogonError=Påloggingstjenesten kjører ikke.
 UacError=Kunne ikke heve.

--- a/Language/nl.ini
+++ b/Language/nl.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Installeer de nieuwe versie
 ClickToInstall=Herstart Rainmeter voor het installeren van versie: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} ondersteunt Windows 7/8 niet. Download Rainmeter versie 4.8 om Rainmeter te gebruiken op Windows 7/8.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} ondersteunt Windows 7/8 niet. Download Rainmeter versie 4.5 om Rainmeter te gebruiken op Windows 7/8.
 AdminError=Beheerdersrechten vereist.
 LogonError=Logon-service wordt niet uitgevoerd.
 UacError=Kan bevoegdheden niet aanvragen.

--- a/Language/pl.ini
+++ b/Language/pl.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Zainstaluj nową wersję
 ClickToInstall=Zrestartuj Rainmeter, aby zainstalować wersję: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} nie jest wspierany przez system Windows 7/8. W celu instalacji w systemie Windows 7/8, pobierz starszą wersję Rainmeter 4.8.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} nie jest wspierany przez system Windows 7/8. W celu instalacji w systemie Windows 7/8, pobierz starszą wersję Rainmeter 4.5.
 AdminError=Do instalacji potrzebne są uprawnienia administratora.
 LogonError=Usługa logowania nie uruchomiona.
 UacError=Nie można podnieść uprawnień.

--- a/Language/pt-BR.ini
+++ b/Language/pt-BR.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Instalar nova versão
 ClickToInstall=Reinicie o Rainmeter para instalar a versão: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} não suporta Windows 7/8. Para usar o Rainmeter no seu computador, faça download da versão mais antiga do Rainmeter 4.8.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} não suporta Windows 7/8. Para usar o Rainmeter no seu computador, faça download da versão mais antiga do Rainmeter 4.5.
 AdminError=Privilégios de administrador são necessários.
 LogonError=Serviço de login não está sendo executado.
 UacError=Não foi possível executar como Administrador.

--- a/Language/pt-PT.ini
+++ b/Language/pt-PT.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Instalar nova versão
 ClickToInstall=Reiniciar o Rainmeter para instalar a versão: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} não suporta o Windows 7/8. Para usar o Rainmeter no Windows 7/8, descarregue Rainmeter 4.8.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} não suporta o Windows 7/8. Para usar o Rainmeter no Windows 7/8, descarregue Rainmeter 4.5.
 AdminError=Direitos de administração necessários.
 LogonError=O serviço de inicio de sessão não está a ser executado.
 UacError=Erro ao obter direitos de instalação.

--- a/Language/ro.ini
+++ b/Language/ro.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Instalare versiune nouă
 ClickToInstall=Repornire Rainmeter pentru instalarea versiunii %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} nu suportă Windows 7/8. Pentru a utiliza Rainmeter în Windows 7/8, descărcaţi versiunea Rainmeter 4.8.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} nu suportă Windows 7/8. Pentru a utiliza Rainmeter în Windows 7/8, descărcaţi versiunea Rainmeter 4.5.
 AdminError=Se solicită drepturi de administrator.
 LogonError=Serviciul logon nu este pornit.
 UacError=Imposibilă ridicarea.

--- a/Language/ru.ini
+++ b/Language/ru.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Установить новую версию
 ClickToInstall=Перезапустить Rainmeter для установки версии: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} не поддерживает Windows 7/8. Чтобы использовать Rainmeter на Windows 7/8, скачайте более старую версию Rainmeter 4.8.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} не поддерживает Windows 7/8. Чтобы использовать Rainmeter на Windows 7/8, скачайте более старую версию Rainmeter 4.5.
 AdminError=Требуются права Администратора.
 LogonError=Служба входа в систему не запущена.
 UacError=Не удается повысить права.

--- a/Language/sk.ini
+++ b/Language/sk.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Nainštalovať novú verziu
 ClickToInstall=Reštartovať Rainmeter a nainštalovať verziu: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} nepodporuje systém Windows 7/8. Na používanie programu Rainmeter v systéme Windows 7/8 si stiahnite staršiu verziu programu Rainmeter 4.8.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} nepodporuje systém Windows 7/8. Na používanie programu Rainmeter v systéme Windows 7/8 si stiahnite staršiu verziu programu Rainmeter 4.5.
 AdminError=Požadované práva administrátora.
 LogonError=Služba prihlasovania nie je aktívna.
 UacError=Zakázaný prístup.

--- a/Language/sl.ini
+++ b/Language/sl.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Install new version
 ClickToInstall=Restart Rainmeter to install version: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} ne podpira Windows 7/8. Za uporabo Rainmetra na Windows 7/8, prenesite starejšo Rainmeter 4.8 različico.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} ne podpira Windows 7/8. Za uporabo Rainmetra na Windows 7/8, prenesite starejšo Rainmeter 4.5 različico.
 AdminError=Potrebne so Administratorske pravice.
 LogonError=Prijavna storitev ne deluje.
 UacError=Ni bilo mogoče dobiti povišanih pravic.

--- a/Language/sr-Cyrl.ini
+++ b/Language/sr-Cyrl.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Инсталирај нову верзију
 ClickToInstall=Поново покрените Rainmeter да бисте инсталирали верзију: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} не подржава Windows 7/8. Да бисте користили Rainmeter на Windows-у 7/8, преузмите старију верзију Rainmeter-а (4.8).
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} не подржава Windows 7/8. Да бисте користили Rainmeter на Windows-у 7/8, преузмите старију верзију Rainmeter-а (4.5).
 AdminError=Потребна су администраторска права.
 LogonError=Услуга пријављивања није покренута.
 UacError=Покретање није могуће.

--- a/Language/sr-Latn.ini
+++ b/Language/sr-Latn.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Instaliraj novu verziju
 ClickToInstall=Ponovo pokrenite Rainmeter da biste instalirali verziju: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} ne podržava Windows 7/8. Da biste koristili Rainmeter na Windows-u 7/8, preuzmite stariju verziju Rainmeter-a (4.8).
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} ne podržava Windows 7/8. Da biste koristili Rainmeter na Windows-u 7/8, preuzmite stariju verziju Rainmeter-a (4.5).
 AdminError=Potrebna su administratorska prava.
 LogonError=Usluga prijavljivanja nije pokrenuta.
 UacError=Pokretanje nije moguće.

--- a/Language/sv.ini
+++ b/Language/sv.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Installera den nya versionen
 ClickToInstall=Starta om Rainmeter för att installera version: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} fungerar inte på Windows 7/8. För att använda Rainmeter på Windows 7/8, ladda ner den äldre versionen 4.8 av Rainmeter.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} fungerar inte på Windows 7/8. För att använda Rainmeter på Windows 7/8, ladda ner den äldre versionen 4.5 av Rainmeter.
 AdminError=Administrativa rättigheter krävs.
 LogonError=Tjänsten Logon körs ej.
 UacError=Kan inte höja UAC-nivån.

--- a/Language/th.ini
+++ b/Language/th.ini
@@ -207,7 +207,7 @@ InstallNewVersion=ติดตั้งเวอร์ชั่นใหม่
 ClickToInstall=รีสตาร์ต Rainmeter เพื่อติดตั้งเวอร์ชั่น : %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} ไม่รองรับ Windows 7/8 หากต้องการใช้ Rainmeter บน Windows 7/8 ให้ดาวน์โหลด Rainmeter 4.8 เวอร์ชันเก่า
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} ไม่รองรับ Windows 7/8 หากต้องการใช้ Rainmeter บน Windows 7/8 ให้ดาวน์โหลด Rainmeter 4.5 เวอร์ชันเก่า
 AdminError=สิทธิ์ของผู้ดูแลระบบที่จำเป็น
 LogonError=บริการเข้าสู่ระบบไม่ทำงาน
 UacError=ไม่สามารถยกระดับได้

--- a/Language/tr.ini
+++ b/Language/tr.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Yeni sürümü yükle
 ClickToInstall=%1 sürümünü yüklemek için Rainmeter'ı yeniden başlat
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} Windows 7/8 üzerinde çalışmaz. Rainmeter'i  Windows 7/8 üzerinde kullanmak için, Rainmeter 4.8 sürümünü indirin.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} Windows 7/8 üzerinde çalışmaz. Rainmeter'i  Windows 7/8 üzerinde kullanmak için, Rainmeter 4.5 sürümünü indirin.
 AdminError=Yönetici hakları gerektirir.
 LogonError=Giriş servisi çalışmıyor.
 UacError=Yükseltilemiyor.

--- a/Language/uk.ini
+++ b/Language/uk.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Встановіть нову версію
 ClickToInstall=Перезапустіть Rainmeter, щоб встановити версію: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} не підтримує Windows 7/8. Щоб використовувати Rainmeter у Windows 7/8, завантажте стару версію Rainmeter 4.8.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} не підтримує Windows 7/8. Щоб використовувати Rainmeter у Windows 7/8, завантажте стару версію Rainmeter 4.5.
 AdminError=Потрібні права адміністратора.
 LogonError=Службу входу до системи не запущено.
 UacError=Не вдалося підвищити права.

--- a/Language/vi.ini
+++ b/Language/vi.ini
@@ -207,7 +207,7 @@ InstallNewVersion=Cài đặt phiên bản mới
 ClickToInstall=Khởi động lại để cài đặt phiên bản mới: %1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} không hỗ trợ Windows 7/8. Để sử dụng Rainmeter trên Windows 7/8, tải bản cũ hơn phiên bản Rainmeter 4.8.
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} không hỗ trợ Windows 7/8. Để sử dụng Rainmeter trên Windows 7/8, tải bản cũ hơn phiên bản Rainmeter 4.5.
 AdminError=Yêu cầu quyền Admin.
 LogonError=Truy cập hệ thống không hoạt động.
 UacError=Không thể nâng cấp.

--- a/Language/zh-CN.ini
+++ b/Language/zh-CN.ini
@@ -207,7 +207,7 @@ InstallNewVersion=安装新版本
 ClickToInstall=重启 Rainmeter 完成新版本 %1 的安装
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} 不支持Windows 7/8。 如果要在Windows 7/8上运行Rainmeter,请下载Rainmeter 4.8或更早版本。
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} 不支持Windows 7/8。 如果要在Windows 7/8上运行Rainmeter,请下载Rainmeter 4.5或更早版本。
 AdminError=需要管理员权限。
 LogonError=Logon 服务未运行。
 UacError=无法创建。

--- a/Language/zh-TW.ini
+++ b/Language/zh-TW.ini
@@ -207,7 +207,7 @@ InstallNewVersion=安裝更新
 ClickToInstall=重新啟動 Rainmeter 來更新軟體版本：%1
 
 [Installer]
-UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} 不支援 Windows 7/8。如果要在 Windows 7/8 上執行 Rainmeter，請下載 Rainmeter 4.8 或更早版本。
+UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} 不支援 Windows 7/8。如果要在 Windows 7/8 上執行 Rainmeter，請下載 Rainmeter 4.5 或更早版本。
 AdminError=需要管理員權限。
 LogonError=Logon 服務未執行。
 UacError=無法建立。


### PR DESCRIPTION
**en.ini** Line 210
from `Rainmeter 4.8 version` to `Rainmeter 4.5 version`

**Before**
```ini
UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} does not support Windows 7/8. To use Rainmeter on Windows 7/8, download the older Rainmeter 4.8 version.
```
**After**
```ini
UnsupportedWindowsError=Rainmeter ${VERSION_SHORT} does not support Windows 7/8. To use Rainmeter on Windows 7/8, download the older Rainmeter 4.5 version.
```


**en.ini**, **es.ini**, ...
from `4.8` to `4.5`

**de.ini**, **ja.ini**
from `2.0` to `4.5`