### PR TITLE
Gfx: Remove misleading and unnecessary shape cloning

### DIFF
--- a/Common/Gfx/Shape.cpp
+++ b/Common/Gfx/Shape.cpp
@@ -506,24 +506,22 @@ void Shape::ValidateTransforms()
 	AddToTransformOrder(TransformType::Offset);
 }
 
-void Shape::CloneModifiers(Shape* otherShape)
+void Shape::CopyStyle(const Shape& otherShape)
 {
-	otherShape->m_StrokeType = m_StrokeType;
-	otherShape->m_TransformModifiers.reset(
-		m_TransformModifiers ? new TransformModifiers(*m_TransformModifiers) : nullptr);
+	m_StrokeType = otherShape.m_StrokeType;
 
-	if (m_StrokeData)
+	if (otherShape.m_StrokeData)
 	{
-		otherShape->m_StrokeData.reset(new StrokeData());
-		otherShape->m_StrokeData->CopyFrom(*m_StrokeData);
-		otherShape->CreateStrokeStyle();
+		m_StrokeData.reset(new StrokeData());
+		m_StrokeData->CopyFrom(*otherShape.m_StrokeData);
+		CreateStrokeStyle();
 	}
 	else
 	{
-		otherShape->m_StrokeData.reset();
+		m_StrokeData.reset();
 	}
 
-	otherShape->m_Fill.CopyFrom(m_Fill);
+	m_Fill.CopyFrom(otherShape.m_Fill);
 }
 
 Shape::TransformModifiers& Shape::GetTransformModifiers()

--- a/Common/Gfx/Shape.h
+++ b/Common/Gfx/Shape.h
@@ -64,8 +64,6 @@ public:
 
 	bool DoesShapeExist() { return m_Shape != nullptr; }
 
-	virtual Shape* Clone() = 0;
-
 	D2D1_MATRIX_3X2_F GetShapeMatrix();
 	D2D1_RECT_F GetBounds(bool useMatrix = true);
 	bool IsShapeDefined();
@@ -74,6 +72,7 @@ public:
 	bool IsCombined() { return m_IsCombined; }
 	void SetCombined() { m_IsCombined = true; }
 	bool CombineWith(Shape* otherShape, D2D1_COMBINE_MODE mode);
+	void CopyStyle(const Shape& otherShape);
 
 	void SetOffset(FLOAT x, FLOAT y) { GetTransformModifiers().offset = D2D1::SizeF(x, y); }
 	void SetStrokeWidth(FLOAT strokeWidth);
@@ -101,8 +100,6 @@ public:
 	void ValidateTransforms();
 
 protected:
-	void CloneModifiers(Shape* otherShape);
-
 	Microsoft::WRL::ComPtr<ID2D1Geometry> m_Shape;
 
 private:

--- a/Common/Gfx/Shapes/Arc.cpp
+++ b/Common/Gfx/Shapes/Arc.cpp
@@ -12,7 +12,7 @@
 namespace Gfx {
 
 Arc::Arc(FLOAT x1, FLOAT y1, FLOAT x2, FLOAT y2, FLOAT xRadius, FLOAT yRadius, FLOAT angle,
-	D2D1_SWEEP_DIRECTION sweep, D2D1_ARC_SIZE size, D2D1_FIGURE_END ending, bool isCloned) : Shape(ShapeType::Arc),
+	D2D1_SWEEP_DIRECTION sweep, D2D1_ARC_SIZE size, D2D1_FIGURE_END ending) : Shape(ShapeType::Arc),
 	m_StartPoint(D2D1::Point2F(x1, y1)),
 	m_ArcSegment(D2D1::ArcSegment(
 		D2D1::Point2F(x2, y2),
@@ -22,9 +22,6 @@ Arc::Arc(FLOAT x1, FLOAT y1, FLOAT x2, FLOAT y2, FLOAT xRadius, FLOAT yRadius, F
 		size)),
 	m_ShapeEnding(ending)
 {
-	// Cloned shapes do not need to re-create any resources
-	if (isCloned) return;
-
 	Microsoft::WRL::ComPtr<ID2D1GeometrySink> sink;
 	Microsoft::WRL::ComPtr<ID2D1PathGeometry> path;
 	HRESULT hr = Canvas::c_D2DFactory->CreatePathGeometry(path.GetAddressOf());
@@ -47,23 +44,5 @@ Arc::~Arc()
 {
 }
 
-Shape* Arc::Clone()
-{
-	Arc* newShape = new Arc(
-		m_StartPoint.x,
-		m_StartPoint.y,
-		m_ArcSegment.point.x,
-		m_ArcSegment.point.y,
-		m_ArcSegment.size.width,
-		m_ArcSegment.size.height,
-		m_ArcSegment.rotationAngle,
-		m_ArcSegment.sweepDirection,
-		m_ArcSegment.arcSize,
-		m_ShapeEnding,
-		true);
-	m_Shape.CopyTo(newShape->m_Shape.GetAddressOf());
-	CloneModifiers(newShape);
-	return newShape;
-}
 
 }  // namespace Gfx

--- a/Common/Gfx/Shapes/Arc.h
+++ b/Common/Gfx/Shapes/Arc.h
@@ -16,10 +16,8 @@ class Arc final : public Shape
 {
 public:
 	Arc(FLOAT x1, FLOAT y1, FLOAT x2, FLOAT y2, FLOAT xRadius, FLOAT yRadius, FLOAT angle,
-		D2D1_SWEEP_DIRECTION sweep, D2D1_ARC_SIZE size, D2D1_FIGURE_END ending, bool isCloned = false);
+		D2D1_SWEEP_DIRECTION sweep, D2D1_ARC_SIZE size, D2D1_FIGURE_END ending);
 	~Arc();
-
-	virtual Shape* Clone() override;
 
 private:
 	Arc(const Arc& other) = delete;

--- a/Common/Gfx/Shapes/Curve.cpp
+++ b/Common/Gfx/Shapes/Curve.cpp
@@ -12,7 +12,7 @@
 namespace Gfx {
 
 Curve::Curve(FLOAT x1, FLOAT y1, FLOAT x2, FLOAT y2, FLOAT cx1, FLOAT cy1, FLOAT cx2,
-	FLOAT cy2, D2D1_FIGURE_END ending, bool isCloned) : Shape(ShapeType::Curve),
+	FLOAT cy2, D2D1_FIGURE_END ending) : Shape(ShapeType::Curve),
 	m_StartPoint(D2D1::Point2F(x1, y1)),
 	m_BezierSegment(D2D1::BezierSegment(
 		D2D1::Point2F(cx1, cy1),
@@ -20,9 +20,6 @@ Curve::Curve(FLOAT x1, FLOAT y1, FLOAT x2, FLOAT y2, FLOAT cx1, FLOAT cy1, FLOAT
 		D2D1::Point2F(x2, y2))),
 	m_ShapeEnding(ending)
 {
-	// Cloned shapes do not need to re-create any resources
-	if (isCloned) return;
-
 	Microsoft::WRL::ComPtr<ID2D1GeometrySink> sink;
 	Microsoft::WRL::ComPtr<ID2D1PathGeometry> path;
 	HRESULT hr = Canvas::c_D2DFactory->CreatePathGeometry(path.GetAddressOf());
@@ -45,22 +42,5 @@ Curve::~Curve()
 {
 }
 
-Shape* Curve::Clone()
-{
-	Curve* newShape = new Curve(
-		m_StartPoint.x,
-		m_StartPoint.y,
-		m_BezierSegment.point3.x,
-		m_BezierSegment.point3.y,
-		m_BezierSegment.point1.x,
-		m_BezierSegment.point1.y,
-		m_BezierSegment.point2.x,
-		m_BezierSegment.point2.y,
-		m_ShapeEnding,
-		true);
-	m_Shape.CopyTo(newShape->m_Shape.GetAddressOf());
-	CloneModifiers(newShape);
-	return newShape;
-}
 
 }  // namespace Gfx

--- a/Common/Gfx/Shapes/Curve.h
+++ b/Common/Gfx/Shapes/Curve.h
@@ -16,10 +16,8 @@ class Curve final : public Shape
 {
 public:
 	Curve(FLOAT x1, FLOAT y1, FLOAT x2, FLOAT y2, FLOAT cx1, FLOAT cy1,
-		FLOAT cx2, FLOAT cy2, D2D1_FIGURE_END ending, bool isCloned = false);
+		FLOAT cx2, FLOAT cy2, D2D1_FIGURE_END ending);
 	~Curve();
-
-	virtual Shape* Clone() override;
 
 private:
 	Curve(const Curve& other) = delete;

--- a/Common/Gfx/Shapes/Ellipse.cpp
+++ b/Common/Gfx/Shapes/Ellipse.cpp
@@ -11,15 +11,11 @@
 
 namespace Gfx {
 
-Ellipse::Ellipse(FLOAT x, FLOAT y, FLOAT xRadius, FLOAT yRadius,
-	bool isCloned) : Shape(ShapeType::Ellipse),
+Ellipse::Ellipse(FLOAT x, FLOAT y, FLOAT xRadius, FLOAT yRadius) : Shape(ShapeType::Ellipse),
 	m_CenterPoint(D2D1::Point2F(x, y)),
 	m_RadiusX(xRadius),
 	m_RadiusY(yRadius)
 {
-	// Cloned shapes do not need to re-create any resources
-	if (isCloned) return;
-
 	const D2D1_ELLIPSE ellipse = D2D1::Ellipse(m_CenterPoint, m_RadiusX, m_RadiusY);
 	Canvas::c_D2DFactory->CreateEllipseGeometry(ellipse, (ID2D1EllipseGeometry**)m_Shape.GetAddressOf());
 }
@@ -28,12 +24,5 @@ Ellipse::~Ellipse()
 {
 }
 
-Shape* Ellipse::Clone()
-{
-	Ellipse* newShape = new Ellipse(m_CenterPoint.x, m_CenterPoint.y, m_RadiusX, m_RadiusY, true);
-	m_Shape.CopyTo(newShape->m_Shape.GetAddressOf());
-	CloneModifiers(newShape);
-	return newShape;
-}
 
 }  // namespace Gfx

--- a/Common/Gfx/Shapes/Ellipse.h
+++ b/Common/Gfx/Shapes/Ellipse.h
@@ -15,11 +15,8 @@ namespace Gfx {
 class Ellipse final : public Shape
 {
 public:
-	Ellipse(FLOAT x, FLOAT y, FLOAT xRadius, FLOAT yRadius,
-		bool isCloned = false);
+	Ellipse(FLOAT x, FLOAT y, FLOAT xRadius, FLOAT yRadius);
 	~Ellipse ();
-
-	virtual Shape* Clone() override;
 
 private:
 	Ellipse(const Ellipse& other) = delete;

--- a/Common/Gfx/Shapes/Line.cpp
+++ b/Common/Gfx/Shapes/Line.cpp
@@ -11,13 +11,10 @@
 
 namespace Gfx {
 
-Line::Line(FLOAT x1, FLOAT y1, FLOAT x2, FLOAT y2, bool isCloned) : Shape(ShapeType::Line),
+Line::Line(FLOAT x1, FLOAT y1, FLOAT x2, FLOAT y2) : Shape(ShapeType::Line),
 	m_StartPoint(D2D1::Point2F(x1, y1)),
 	m_EndPoint(D2D1::Point2F(x2, y2))
 {
-	// Cloned shapes do not need to re-create any resources
-	if (isCloned) return;
-
 	Microsoft::WRL::ComPtr<ID2D1GeometrySink> sink;
 	Microsoft::WRL::ComPtr<ID2D1PathGeometry> path;
 	HRESULT hr = Canvas::c_D2DFactory->CreatePathGeometry(path.GetAddressOf());
@@ -40,12 +37,5 @@ Line::~Line()
 {
 }
 
-Shape* Line::Clone()
-{
-	Line* newShape = new Line(m_StartPoint.x, m_StartPoint.y, m_EndPoint.x, m_EndPoint.y, true);
-	m_Shape.CopyTo(newShape->m_Shape.GetAddressOf());
-	CloneModifiers(newShape);
-	return newShape;
-}
 
 }  // namespace Gfx

--- a/Common/Gfx/Shapes/Line.h
+++ b/Common/Gfx/Shapes/Line.h
@@ -15,10 +15,8 @@ namespace Gfx {
 class Line final : public Shape
 {
 public:
-	Line(FLOAT x1, FLOAT y1, FLOAT x2, FLOAT y2, bool isCloned = false);
+	Line(FLOAT x1, FLOAT y1, FLOAT x2, FLOAT y2);
 	~Line();
-
-	virtual Shape* Clone() override;
 
 private:
 	Line(const Line& other) = delete;

--- a/Common/Gfx/Shapes/Path.cpp
+++ b/Common/Gfx/Shapes/Path.cpp
@@ -11,13 +11,10 @@
 
 namespace Gfx {
 
-Path::Path(FLOAT x, FLOAT y, D2D1_FILL_MODE fillMode, bool isCloned) : Shape(ShapeType::Path),
+Path::Path(FLOAT x, FLOAT y, D2D1_FILL_MODE fillMode) : Shape(ShapeType::Path),
 	m_StartPoint(D2D1::Point2F(x, y)),
 	m_FillMode(fillMode)
 {
-	// Cloned shapes do not need to re-create any resources
-	if (isCloned) return;
-
 	HRESULT hr = Canvas::c_D2DFactory->CreatePathGeometry(m_Path.GetAddressOf());
 	if (SUCCEEDED(hr))
 	{
@@ -40,13 +37,6 @@ void Path::Dispose()
 	if (m_Sink) m_Sink.Reset();
 }
 
-Shape* Path::Clone()
-{
-	Path* newShape = new Path(m_StartPoint.x, m_StartPoint.y, m_FillMode, true);
-	m_Shape.CopyTo(newShape->m_Shape.GetAddressOf());
-	CloneModifiers(newShape);
-	return newShape;
-}
 
 void Path::AddLine(FLOAT x, FLOAT y)
 {

--- a/Common/Gfx/Shapes/Path.h
+++ b/Common/Gfx/Shapes/Path.h
@@ -15,7 +15,7 @@ namespace Gfx {
 class Path final : public Shape
 {
 public:
-	Path(FLOAT x, FLOAT y, D2D1_FILL_MODE fillMode, bool isCloned = false);
+	Path(FLOAT x, FLOAT y, D2D1_FILL_MODE fillMode);
 	~Path();
 
 	void AddLine(FLOAT x, FLOAT y);
@@ -25,8 +25,6 @@ public:
 	void AddCubicCurve(FLOAT x, FLOAT y, FLOAT cx1, FLOAT cy1, FLOAT cx2, FLOAT cy2);
 	void SetSegmentFlags(D2D1_PATH_SEGMENT flags);
 	void Close(D2D1_FIGURE_END ending);
-
-	virtual Shape* Clone() override;
 
 private:
 	Path(const Path& other) = delete;

--- a/Common/Gfx/Shapes/QuadraticCurve.cpp
+++ b/Common/Gfx/Shapes/QuadraticCurve.cpp
@@ -12,16 +12,13 @@
 namespace Gfx {
 
 QuadraticCurve::QuadraticCurve(FLOAT x1, FLOAT y1, FLOAT x2, FLOAT y2, FLOAT cx, FLOAT cy,
-	D2D1_FIGURE_END ending, bool isCloned) : Shape(ShapeType::QuadraticCurve),
+	D2D1_FIGURE_END ending) : Shape(ShapeType::QuadraticCurve),
 	m_StartPoint(D2D1::Point2F(x1, y1)),
 	m_QuadraticBezierSegment(D2D1::QuadraticBezierSegment(
 		D2D1::Point2F(cx, cy),
 		D2D1::Point2F(x2, y2))),
 	m_ShapeEnding(ending)
 {
-	// Cloned shapes do not need to re-create any resources
-	if (isCloned) return;
-
 	Microsoft::WRL::ComPtr<ID2D1GeometrySink> sink;
 	Microsoft::WRL::ComPtr<ID2D1PathGeometry> path;
 	HRESULT hr = Canvas::c_D2DFactory->CreatePathGeometry(path.GetAddressOf());
@@ -44,20 +41,5 @@ QuadraticCurve::~QuadraticCurve()
 {
 }
 
-Shape* QuadraticCurve::Clone()
-{
-	QuadraticCurve* newShape = new QuadraticCurve(
-		m_StartPoint.x,
-		m_StartPoint.y,
-		m_QuadraticBezierSegment.point2.x,
-		m_QuadraticBezierSegment.point2.y,
-		m_QuadraticBezierSegment.point1.x,
-		m_QuadraticBezierSegment.point1.y,
-		m_ShapeEnding,
-		true);
-	m_Shape.CopyTo(newShape->m_Shape.GetAddressOf());
-	CloneModifiers(newShape);
-	return newShape;
-}
 
 }  // namespace Gfx

--- a/Common/Gfx/Shapes/QuadraticCurve.h
+++ b/Common/Gfx/Shapes/QuadraticCurve.h
@@ -16,10 +16,8 @@ class QuadraticCurve final : public Shape
 {
 public:
 	QuadraticCurve(FLOAT x1, FLOAT y1, FLOAT x2, FLOAT y2, FLOAT cx,
-		FLOAT cy, D2D1_FIGURE_END ending, bool isCloned = false);
+		FLOAT cy, D2D1_FIGURE_END ending);
 	~QuadraticCurve();
-
-	virtual Shape* Clone() override;
 
 private:
 	QuadraticCurve(const QuadraticCurve& other) = delete;

--- a/Common/Gfx/Shapes/Rectangle.cpp
+++ b/Common/Gfx/Shapes/Rectangle.cpp
@@ -11,15 +11,12 @@
 
 namespace Gfx {
 
-Rectangle::Rectangle(FLOAT x, FLOAT y, FLOAT width, FLOAT height, bool isCloned) : Shape(ShapeType::Rectangle),
+Rectangle::Rectangle(FLOAT x, FLOAT y, FLOAT width, FLOAT height) : Shape(ShapeType::Rectangle),
 	m_X(x),
 	m_Y(y),
 	m_Width(width + x),
 	m_Height(height + y)
 {
-	// Cloned shapes do not need to re-create any resources
-	if (isCloned) return;
-
 	const D2D1_RECT_F rect = { m_X, m_Y, m_Width, m_Height };
 	Canvas::c_D2DFactory->CreateRectangleGeometry(rect, (ID2D1RectangleGeometry**)m_Shape.GetAddressOf());
 }
@@ -28,12 +25,5 @@ Rectangle::~Rectangle()
 {
 }
 
-Shape* Rectangle::Clone()
-{
-	Rectangle* newShape = new Rectangle(m_X, m_Y, m_Width - m_X, m_Height - m_Y, true);
-	m_Shape.CopyTo(newShape->m_Shape.GetAddressOf());
-	CloneModifiers(newShape);
-	return newShape;
-}
 
 }  // namespace Gfx

--- a/Common/Gfx/Shapes/Rectangle.h
+++ b/Common/Gfx/Shapes/Rectangle.h
@@ -15,10 +15,8 @@ namespace Gfx {
 class Rectangle final : public Shape
 {
 public:
-	Rectangle(FLOAT x, FLOAT y, FLOAT width, FLOAT height, bool isCloned = false);
+	Rectangle(FLOAT x, FLOAT y, FLOAT width, FLOAT height);
 	~Rectangle();
-
-	virtual Shape* Clone() override;
 
 private:
 	Rectangle(const Rectangle& other) = delete;

--- a/Common/Gfx/Shapes/RoundedRectangle.cpp
+++ b/Common/Gfx/Shapes/RoundedRectangle.cpp
@@ -12,7 +12,7 @@
 namespace Gfx {
 
 RoundedRectangle::RoundedRectangle(FLOAT x, FLOAT y, FLOAT width, FLOAT height,
-	FLOAT xRadius, FLOAT yRadius, bool isCloned) : Shape(ShapeType::RoundedRectangle),
+	FLOAT xRadius, FLOAT yRadius) : Shape(ShapeType::RoundedRectangle),
 		m_X(x),
 		m_Y(y),
 		m_Width(width + x),
@@ -20,9 +20,6 @@ RoundedRectangle::RoundedRectangle(FLOAT x, FLOAT y, FLOAT width, FLOAT height,
 		m_XRadius(xRadius),
 		m_YRadius(yRadius)
 {
-	// Cloned shapes do not need to re-create any resources
-	if (isCloned) return;
-
 	const D2D1_ROUNDED_RECT rect = { m_X, m_Y, m_Width, m_Height, m_XRadius, m_YRadius };
 	Canvas::c_D2DFactory->CreateRoundedRectangleGeometry(rect, (ID2D1RoundedRectangleGeometry**)m_Shape.GetAddressOf());
 }
@@ -31,12 +28,5 @@ RoundedRectangle::~RoundedRectangle()
 {
 }
 
-Shape* RoundedRectangle::Clone()
-{
-	RoundedRectangle* newShape = new RoundedRectangle(m_X, m_Y, m_Width - m_X, m_Height - m_Y, m_XRadius, m_YRadius, true);
-	m_Shape.CopyTo(newShape->m_Shape.GetAddressOf());
-	CloneModifiers(newShape);
-	return newShape;
-}
 
 }  // namespace Gfx

--- a/Common/Gfx/Shapes/RoundedRectangle.h
+++ b/Common/Gfx/Shapes/RoundedRectangle.h
@@ -16,10 +16,8 @@ class RoundedRectangle final : public Shape
 {
 public:
 	RoundedRectangle(FLOAT x, FLOAT y, FLOAT width, FLOAT height,
-		FLOAT xRadius, FLOAT yRadius, bool isCloned = false);
+		FLOAT xRadius, FLOAT yRadius);
 	~RoundedRectangle();
-
-	virtual Shape* Clone() override;
 
 private:
 	RoundedRectangle(const RoundedRectangle& other) = delete;

--- a/Library/MeterShape.cpp
+++ b/Library/MeterShape.cpp
@@ -488,25 +488,15 @@ bool MeterShape::CreateCombinedShape(ConfigParser& parser, size_t shapeId, std::
 
 		if (parentId < m_Shapes.size())
 		{
-			Gfx::Shape* clonedShape = m_Shapes[parentId]->Clone();
-			if (clonedShape)
+			Gfx::Shape* parentShape = m_Shapes[parentId];
+			m_Shapes[shapeId]->CopyStyle(*parentShape);
+			if (m_Shapes[shapeId]->CombineWith(parentShape, D2D1_COMBINE_MODE_UNION))
 			{
-				// Delete and remove the shape from |m_Shapes|, then
-				// insert the cloned shape into the position of the
-				// deleted shape.
-
-				delete m_Shapes[shapeId];
-				auto iter = m_Shapes.erase(m_Shapes.begin() + shapeId);
-				m_Shapes.insert(iter, clonedShape);
-
-				m_Shapes[parentId]->SetCombined();
-
-				// Combine with empty shape
-				m_Shapes[shapeId]->CombineWith(nullptr, D2D1_COMBINE_MODE_UNION);
+				parentShape->SetCombined();
 			}
 			else
 			{
-				// Shape could not be cloned
+				showError(L"could not combine with: Shape", parentName.c_str());
 				return false;
 			}
 		}


### PR DESCRIPTION

- The existing `Clone()` flow for `Gfx::Shape` subclasses produced shared geometry references and provided no true independent copy, so cloning semantics were misleading. 
- Combined-shape creation previously relied on cloning-and-replacing which is unnecessary given shared geometry behavior and complicated the combine logic. 