### PR TITLE
NowPlaying/Cover: Add .webp and .avif local cover support

### DIFF
--- a/Library/NowPlaying/Cover.cpp
+++ b/Library/NowPlaying/Cover.cpp
@@ -113,8 +113,8 @@ bool CCover::GetLocal(std::wstring filename, const std::wstring& folder, std::ws
 	testPath += L".";
 	std::wstring::size_type origLen = testPath.length();
 
-	const int extCount = 4;
-	LPCTSTR extName[extCount] = { L"jpg", L"jpeg", L"png", L"bmp" };
+	const int extCount = 6;
+	LPCTSTR extName[extCount] = { L"jpg", L"jpeg", L"png", L"bmp", L"webp", L"avif" };
 
 	for (int i = 0; i < extCount; ++i)
 	{


### PR DESCRIPTION
Rainmeter supports displaying .webp and .avif images, but those extensions are missing when displaying a cover from a local file.

Should the order of extensions be rearranged to prioritize newer formats? Maybe `L"avif", L"webp", L"png", L"jpg", L"jpeg", L"bmp"` . Should it be changed to `LPCTSTR extName[]` and `i < _countof(extName)` to eliminate the `extCount` constant? Or even `const auto& i : extName`?