### PR TITLE
Defer Rainmeter.ini writes from window-state bangs

### DIFF
--- a/Library/Skin.cpp
+++ b/Library/Skin.cpp
@@ -29,6 +29,7 @@
 #include "../Version.h"
 #include "../Common/DpiUtil.h"
 #include "../Common/PathUtil.h"
+#include "../Common/ScopedFunction.h"
 #include "../Common/StringUtil.h"
 #include "../Common/Gfx/Util/EffectStream.h"
 
@@ -43,17 +44,19 @@ enum TIMER
 	TIMER_DEACTIVATE = 5,
 	TIMER_PREVENT_MOVE = 6,
 	TIMER_CARET = 7,
+	TIMER_WRITE_OPTIONS = 8,
 
 	// Update this when adding a new timer.
-	TIMER_MAX = 7
+	TIMER_MAX = 8
 };
 
 enum INTERVAL
 {
-	INTERVAL_METER      = 1000,
-	INTERVAL_MOUSE      = 500,
-	INTERVAL_FADE       = 10,
-	INTERVAL_TRANSITION = 100
+	INTERVAL_METER         = 1000,
+	INTERVAL_MOUSE         = 500,
+	INTERVAL_FADE          = 10,
+	INTERVAL_TRANSITION    = 100,
+	INTERVAL_WRITE_OPTIONS = 10000
 };
 
 int Skin::c_InstanceCount = 0;
@@ -73,6 +76,8 @@ Skin::Skin(const std::wstring& folderPath, const std::wstring& file, const bool 
 	m_SelectionOverlay(),
 	m_DropTarget(),
 	m_PendingWriteOptions(0),
+	m_DeferOptionWrites(false),
+	m_WriteOptionsScheduled(false),
 	m_SuspendResumeNotification(nullptr),
 	m_Mouse(this),
 	m_MouseOver(false),
@@ -203,6 +208,8 @@ void Skin::Dispose(bool refresh)
 	KillTimer(m_Window, TIMER_TRANSITION);
 	KillTimer(m_Window, TIMER_PREVENT_MOVE);
 	KillTimer(m_Window, TIMER_CARET);
+
+	WriteDeferredOptions();
 
 	m_ActiveFade = false;
 	m_FadeStartTime = 0;
@@ -462,11 +469,7 @@ void Skin::Refresh(bool init, bool all)
 
 	LogNoticeF(this, L"Refreshing skin");
 
-	if (m_PendingWriteOptions != 0)
-	{
-		WriteOptions(m_PendingWriteOptions);
-		m_PendingWriteOptions = 0;
-	}
+	WriteDeferredOptions();
 
 	SetResizeWindowMode(RESIZEMODE_RESET);
 
@@ -943,11 +946,7 @@ void Skin::Deselect()
 
 	m_SelectionOverlay.reset();
 
-	if (m_PendingWriteOptions != 0)
-	{
-		WriteOptions(m_PendingWriteOptions);
-		m_PendingWriteOptions = 0;
-	}
+	WriteDeferredOptions();
 
 	for (const auto& meter : m_Meters) meter->ResetToolTip();
 
@@ -1074,6 +1073,10 @@ void Skin::ChangeSingleZPos(ZPOSITION zPos, bool all)
 // Correct number of arguments must be passed (or use Rainmeter::ExecuteBang).
 void Skin::DoBang(Bang bang, const std::vector<std::wstring>& args)
 {
+	const bool oldDeferOptionWrites = m_DeferOptionWrites;
+	m_DeferOptionWrites = true;
+	auto deferScope = Scoped([&] { m_DeferOptionWrites = oldDeferOptionWrites; });
+
 	switch (bang)
 	{
 	case Bang::Refresh:
@@ -2284,13 +2287,28 @@ void Skin::WriteOptions(INT setting)
 		ComputeOptionValueFromPosition();
 	}
 
-	if (IsSelected())
+	if (IsSelected() || m_DeferOptionWrites)
 	{
 		m_PendingWriteOptions |= setting;
 		if (setting != OPTION_ALL)
 		{
 			DialogManage::UpdateSkins(this);
 		}
+
+		if (m_DeferOptionWrites && !m_WriteOptionsScheduled)
+		{
+			m_WriteOptionsScheduled = true;
+
+			SetTimer(m_Window, TIMER_WRITE_OPTIONS, INTERVAL_WRITE_OPTIONS, [](HWND window, UINT, UINT_PTR timerId, DWORD)
+				{
+					auto* skin = (Skin*)GetWindowLongPtr(window, GWLP_USERDATA);
+					if (skin)
+					{
+						skin->WriteDeferredOptions();
+					}
+				});
+		}
+
 		return;
 	}
 
@@ -2395,6 +2413,18 @@ void Skin::WriteOptions(INT setting)
 			_itow_s(m_WindowZPosition, buffer, 10);
 			WritePrivateProfileString(section, L"AlwaysOnTop", buffer, iniFile);
 		}
+	}
+}
+
+void Skin::WriteDeferredOptions()
+{
+	KillTimer(m_Window, TIMER_WRITE_OPTIONS);
+	m_WriteOptionsScheduled = false;
+
+	if (m_PendingWriteOptions != 0)
+	{
+		WriteOptions(m_PendingWriteOptions);
+		m_PendingWriteOptions = 0;
 	}
 }
 

--- a/Library/Skin.h
+++ b/Library/Skin.h
@@ -369,6 +369,7 @@ private:
 	void UpdateWindowTransparency(int alpha);
 	void ReadOptions(ConfigParser& parser, LPCWSTR section, bool isDefault);
 	void WriteOptions(INT setting = OPTION_ALL);
+	void WriteDeferredOptions();
 	bool ReadSkin();
 	void ShowWindowIfAppropriate();
 	HWND GetWindowFromPoint(POINT pos);
@@ -428,6 +429,8 @@ private:
 	SkinDropTarget* m_DropTarget;
 
 	int m_PendingWriteOptions;
+	bool m_DeferOptionWrites;
+	bool m_WriteOptionsScheduled;
 
 	HPOWERNOTIFY m_SuspendResumeNotification;
 


### PR DESCRIPTION
Fixes #471

### Summary of Changes
Bangs that modify window/skin states (`!ZPos`, `!Draggable`, `!ClickThrough`, `!SnapEdges`, `!KeepOnScreen`, and `!AutoSelectScreen`) were calling setter methods that unconditionally wrote settings to `Rainmeter.ini` via `WriteOptions(...)`.

When skins use these bangs dynamically in fast update loops or interactive animations, this resulted in continuous, rapid disk writes and unnecessary SSD wear.

### Solution
1. **Scoped Deferral in `Skin::DoBang()`**: Set `m_DeferOptionWrites = true` at the start of `Skin::DoBang()` using `Scoped` to restore it on exit. This avoids altering any setter function signatures (`SetWindowZPosition`, `SetClickThrough`, etc.).
2. **Debounced Disk Writes in `WriteOptions()`**: In `Skin::WriteOptions()`, when `m_DeferOptionWrites` is active, option flags accumulate into `m_PendingWriteOptions` and schedule a 10-second debounce timer (`TIMER_WRITE_OPTIONS`), guarded by `m_WriteOptionsScheduled` so subsequent bangs do not repeatedly postpone the timer.
3. **Extracted `WriteDeferredOptions()` Flush Helper**: Centralized the timer cleanup and pending write flush into `WriteDeferredOptions()`, which is called upon:
   - Debounce timer expiration
   - Skin unload / Rainmeter shutdown (`Skin::Dispose`)
   - Skin refresh (`Skin::Refresh`)
   - Skin deselection (`Skin::Deselect`)
4. **Preserved Immediate Writes for UI & Menus**: Since `m_DeferOptionWrites` is only set during bang execution, all user changes made through the Manage Dialog and context menus continue to write immediately to disk as expected.
